### PR TITLE
Enable dependabot version updates for Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+    - package-ecosystem: "cargo"
+        directory: "/"
+        schedule:
+            interval: "daily"
+    - package-ecosystem: "cargo"
+        directory: "internal/rcrt1"
+        schedule:
+            interval: "daily"
+    - package-ecosystem: "cargo"
+        directory: "internal/sallyport"
+        schedule:
+            interval: "daily"
+    - package-ecosystem: "cargo"
+        directory: "internal/shim-sev"
+        schedule:
+            interval: "daily"
+    - package-ecosystem: "cargo"
+        directory: "internal/shim-sgx"
+        schedule:
+            interval: "daily"


### PR DESCRIPTION
As discussed in today's standup. It's currently set to run daily.

Resolves #30.