### PR TITLE
Let cargo print a warning, if `strip` fails.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -191,7 +191,7 @@ fn main() {
         match status {
             Ok(status) if status.success() => {}
             _ => {
-                eprintln!("Failed to run strip");
+                println!("cargo:warning=Failed to run `strip` on {:?}", &shim_out_bin);
                 std::fs::rename(&shim_out_bin, &out_bin).expect("move failed")
             }
         }


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@redhat.com>

<!-- 
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #123" or "Resolves enarx/repo-name#123", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
