### PR TITLE
shim-sev: save and restore rcx and r11 for syscalls

### DIFF
--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -53,6 +53,8 @@ pub unsafe fn _syscall_enter() -> ! {
     push   rdi
     push   rsi
     push   rdx
+    push   rcx
+    push   r11
     push   r10
     push   r8
     push   r9
@@ -69,6 +71,8 @@ pub unsafe fn _syscall_enter() -> ! {
     pop    r9
     pop    r8
     pop    r10
+    pop    r11
+    pop    rcx
     pop    rdx
     pop    rsi
     pop    rdi


### PR DESCRIPTION
Do not leak any register contents.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!-- 
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #123" or "Resolves enarx/repo-name#123", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
