### PR TITLE
Use a matrix for `cargo deny` to cover the subcrates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,3 +81,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          arguments: --manifest-path=${{ matrix.crate.path }}
+    strategy:
+      fail-fast: false
+      matrix:
+        crate:
+          - {name: enarx-keepldr, path: ./Cargo.toml}
+          - {name: rcrt1, path: internal/rcrt1/Cargo.toml}
+          - {name: sgx-heap, path: internal/sgx-heap/Cargo.toml}
+          - {name: sallyport, path: internal/sallyport/Cargo.toml}
+          - {name: shim-sgx, path: internal/shim-sgx/Cargo.toml}
+          - {name: shim-sev, path: internal/shim-sev/Cargo.toml}


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@redhat.com>

<!-- 
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #123" or "Resolves enarx/repo-name#123", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
