### PR TITLE
Check in a toolchain file that rustup is aware of

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ technologies such as Intel SGX or AMD SEV.
 
     $ git clone https://github.com/enarx/enarx-keepldr
     $ cd enarx-keepldr/
-    $ cargo +nightly build
+    $ cargo build
 
 ## Run Tests
 
-    $ cargo +nightly test
+    $ cargo test
 
 ## Build and Run an Application
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,11 +25,11 @@
 //!
 //!     $ git clone https://github.com/enarx/enarx-keepldr
 //!     $ cd enarx-keepldr/
-//!     $ cargo +nightly build
+//!     $ cargo build
 //!
 //! # Run Tests
 //!
-//!     $ cargo +nightly test
+//!     $ cargo test
 //!
 //! # Build and Run an Application
 //!


### PR DESCRIPTION
Rustup will automatically use the toolchain version described in this file, meaning we no longer have to instruct people to use a nightly override by hand.