### PR TITLE
Execute a simple `echo` rust test program.

### DIFF
--- a/internal/shim-sgx/src/event.rs
+++ b/internal/shim-sgx/src/event.rs
@@ -52,6 +52,7 @@ pub extern "C" fn event(
                         libc::SYS_clock_gettime => h.clock_gettime(),
                         libc::SYS_madvise => h.madvise(),
                         libc::SYS_close => h.close(),
+                        libc::SYS_poll => h.poll(),
 
                         _ if !crate::handler::TRACE => Err(libc::ENOSYS),
                         syscall => {

--- a/tests/bin/echo.rs
+++ b/tests/bin/echo.rs
@@ -1,0 +1,8 @@
+use std::io::{self, Read, Write};
+
+fn main() -> io::Result<()> {
+    let mut buffer = Vec::new();
+    std::io::stdin().read_to_end(&mut buffer)?;
+    std::io::stdout().write_all(&buffer)?;
+    Ok(())
+}


### PR DESCRIPTION
This builds any `tests/bin/*.rs` found, which can be used for
integration tests.

A simple `echo.rs` test writing every `stdin` to `stdout` is added.

Because this uses `poll`, the `poll` syscall was also implemented for
the `sgx` and `sev` shims.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!-- 
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #123" or "Resolves enarx/repo-name#123", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
