### PR TITLE
shim-sev: unlock hostcall to print PanicInfo

### DIFF
--- a/internal/shim-sev/src/main.rs
+++ b/internal/shim-sev/src/main.rs
@@ -42,6 +42,7 @@ use primordial::Address;
 use sallyport::Block;
 use spinning::RwLock;
 
+use crate::hostcall::HOST_CALL;
 pub use hostlib::BootInfo;
 
 static C_BIT_MASK: AtomicU64 = AtomicU64::new(0);
@@ -143,6 +144,8 @@ pub fn panic(info: &core::panic::PanicInfo) -> ! {
             .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
         {
+            // panic info is useful
+            HOST_CALL.force_unlock();
             eprintln!("{}", info);
             // FIXME: might want to have a custom panic hostcall
             hostcall::shim_exit(255);


### PR DESCRIPTION
In case of a panic, we force get `HOST_CALL` mutex to print the panic
message.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!-- 
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #123" or "Resolves enarx/repo-name#123", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
