### PR TITLE
keepldr(kvm/sev): do a register dump on unexpected shutdown

### DIFF
--- a/src/backend/kvm/vm/cpu.rs
+++ b/src/backend/kvm/vm/cpu.rs
@@ -142,7 +142,13 @@ impl Thread for Cpu {
                 }
                 _ => Err(anyhow!("data from unexpected port: {}", port)),
             },
-            exit_reason => Err(anyhow!("{:?}", exit_reason)),
+            exit_reason => {
+                if cfg!(debug_assertions) {
+                    Err(anyhow!("{:?} {:#x?}", exit_reason, self.fd.get_regs()))
+                } else {
+                    Err(anyhow!("{:?}"))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
For debugging this info is crucial.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!-- 
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #123" or "Resolves enarx/repo-name#123", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
