### PR TITLE
switch away from lazy_static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.21"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -541,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/internal/shim-sev/Cargo.lock
+++ b/internal/shim-sev/Cargo.lock
@@ -41,15 +41,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,7 +124,6 @@ dependencies = [
  "compiler_builtins",
  "crt0stack",
  "goblin",
- "lazy_static",
  "libc",
  "lset",
  "nbytes",
@@ -144,12 +134,6 @@ dependencies = [
  "walkdir",
  "x86_64",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spinning"

--- a/internal/shim-sev/Cargo.toml
+++ b/internal/shim-sev/Cargo.toml
@@ -14,7 +14,6 @@ sallyport = { path = "../sallyport", default-features = false }
 rcrt1 = { path = "../rcrt1" }
 compiler_builtins = { version = "0.1", default-features = false, features = [ "mem" ] }
 x86_64 = { version = "0.12", default-features = false, features = ["instructions", "inline_asm"] }
-lazy_static = { version = "1.4.0", default-features = false, features = ["spin_no_std"] }
 goblin = { version = "0.2", default-features = false, features = [ "elf64" ] }
 crt0stack = { version = "0.1", default-features = false }
 spinning = { version = "0.0", default-features = false }

--- a/internal/shim-sev/src/lazy.rs
+++ b/internal/shim-sev/src/lazy.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! lazy_static! replacement
+//!
+//! Inspired, partially copied, and adopted to `spinning`
+//! from https://github.com/matklad/once_cell
+//! and `std::lazy::Lazy`
+
+use core::cell::Cell;
+use core::ops::Deref;
+use spinning::{Once, OnceState};
+
+/// A value which is initialized on the first access.
+///
+/// This type is thread-safe and can be used in statics.
+///
+/// # Example
+///
+/// ```
+/// use std::collections::HashMap;
+///
+/// use spinning::Lazy;
+///
+/// static HASHMAP: Lazy<HashMap<i32, String>> = Lazy::new(|| {
+///     println!("initializing");
+///     let mut m = HashMap::new();
+///     m.insert(13, "Spica".to_string());
+///     m.insert(74, "Hoyten".to_string());
+///     m
+/// });
+///
+/// fn main() {
+///     println!("ready");
+///     std::thread::spawn(|| {
+///         println!("{:?}", HASHMAP.get(&13));
+///     }).join().unwrap();
+///     println!("{:?}", HASHMAP.get(&74));
+///
+///     // Prints:
+///     //   ready
+///     //   initializing
+///     //   Some("Spica")
+///     //   Some("Hoyten")
+/// }
+/// ```
+pub struct Lazy<T, F = fn() -> T> {
+    once: Once<T>,
+    init: Cell<Option<F>>,
+}
+
+// We never create a `&F` from a `&Lazy<T, F>` so it is fine
+// to not impl `Sync` for `F`
+// we do create a `&mut Option<F>` in `force`, but this is
+// properly synchronized, so it only happens once
+// so it also does not contribute to this impl.
+unsafe impl<T, F: Send> Sync for Lazy<T, F> where Once<T>: Sync {}
+// auto-derived `Send` impl is OK.
+
+impl<T, F> Lazy<T, F> {
+    /// Creates a new lazy value with the given initializing
+    /// function.
+    #[inline(always)]
+    pub const fn new(f: F) -> Lazy<T, F> {
+        Lazy {
+            once: Once::new(),
+            init: Cell::new(Some(f)),
+        }
+    }
+}
+
+impl<T, F: FnOnce() -> T> Lazy<T, F> {
+    /// Forces the evaluation of this lazy value and
+    /// returns a reference to the result. This is equivalent
+    /// to the `Deref` impl, but is explicit.
+    ///
+    /// # Example
+    /// ```
+    /// use spinning::Lazy;
+    ///
+    /// let lazy = Lazy::new(|| 92);
+    ///
+    /// assert_eq!(Lazy::force(&lazy), &92);
+    /// assert_eq!(&*lazy, &92);
+    /// ```
+    #[inline(always)]
+    pub fn force(this: &Lazy<T, F>) -> &T {
+        this.once.call_once(|| match this.init.take() {
+            Some(f) => f(),
+            None => panic!("Lazy instance has previously been poisoned"),
+        })
+    }
+
+    /// Get the current state
+    pub fn state(&self) -> OnceState {
+        self.once.state()
+    }
+}
+
+impl<T, F: FnOnce() -> T> Deref for Lazy<T, F> {
+    type Target = T;
+    #[inline(always)]
+    fn deref(&self) -> &T {
+        Lazy::force(self)
+    }
+}
+
+impl<T: Default> Default for Lazy<T> {
+    /// Creates a new lazy value using `Default` as the initializing function.
+    #[inline(always)]
+    fn default() -> Lazy<T> {
+        Lazy::new(T::default)
+    }
+}

--- a/internal/shim-sev/src/main.rs
+++ b/internal/shim-sev/src/main.rs
@@ -12,9 +12,6 @@
 #![no_main]
 #![feature(asm, naked_functions)]
 
-#[macro_use]
-extern crate lazy_static;
-
 extern crate compiler_builtins;
 extern crate rcrt1;
 
@@ -31,6 +28,7 @@ pub mod payload;
 pub mod shim_stack;
 #[macro_use]
 pub mod print;
+pub mod lazy;
 pub mod random;
 pub mod syscall;
 pub mod usermode;
@@ -104,9 +102,6 @@ macro_rules! entry_point {
 
             // make a local copy of boot_info, before the shared page gets overwritten
             BOOT_INFO.write().replace(boot_info.read_volatile());
-
-            // Needed for syscalls
-            lazy_static::initialize(&frame_allocator::FRAME_ALLOCATOR);
 
             // Switch the stack to a guarded stack
             switch_shim_stack(f, gdt::INITIAL_STACK.pointer.as_u64())

--- a/internal/shim-sev/src/paging.rs
+++ b/internal/shim-sev/src/paging.rs
@@ -4,19 +4,18 @@
 
 use crate::addr::SHIM_VIRT_OFFSET;
 use crate::get_cbit_mask;
+use crate::lazy::Lazy;
 
 use spinning::RwLock;
 use x86_64::structures::paging::{OffsetPageTable, PageTable};
 use x86_64::VirtAddr;
 
-lazy_static! {
-    /// The global `OffsetPageTable` of the shim
-    pub static ref SHIM_PAGETABLE: RwLock<OffsetPageTable<'static>> = {
-        RwLock::<OffsetPageTable<'static>>::const_new(spinning::RawRwLock::const_new(), unsafe {
-            init()
-        })
-    };
-}
+/// The global `OffsetPageTable` of the shim
+pub static SHIM_PAGETABLE: Lazy<RwLock<OffsetPageTable<'static>>> = Lazy::new(|| {
+    RwLock::<OffsetPageTable<'static>>::const_new(spinning::RawRwLock::const_new(), unsafe {
+        init()
+    })
+});
 
 /// Initialize a new OffsetPageTable.
 ///

--- a/internal/shim-sev/src/print.rs
+++ b/internal/shim-sev/src/print.rs
@@ -2,11 +2,13 @@
 
 //! Functions and macros to output text on the host
 
+use crate::frame_allocator::FRAME_ALLOCATOR;
 use crate::hostcall::{self, HostFd};
 
 struct HostWrite(HostFd);
 
 use core::fmt;
+use spinning::OnceState;
 
 // FIXME: remove, if https://github.com/enarx/enarx/issues/831 is fleshed out
 const TRACE: bool = false;
@@ -24,7 +26,7 @@ impl fmt::Write for HostWrite {
 pub fn _print(args: fmt::Arguments) {
     use fmt::Write;
 
-    if !TRACE {
+    if !TRACE || FRAME_ALLOCATOR.state().ne(&OnceState::Initialized) {
         return;
     }
 
@@ -38,7 +40,7 @@ pub fn _print(args: fmt::Arguments) {
 pub fn _eprint(args: fmt::Arguments) {
     use fmt::Write;
 
-    if !TRACE {
+    if !TRACE || FRAME_ALLOCATOR.state().ne(&OnceState::Initialized) {
         return;
     }
 


### PR DESCRIPTION
Use a similar `Lazy` as the experimental `std::lazy::Lazy`.

lazy_static is unmaintained.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!-- 
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #123" or "Resolves enarx/repo-name#123", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
