### PR TITLE
Improve the sallyport cursor data handling

### DIFF
--- a/internal/sallyport/src/lib.rs
+++ b/internal/sallyport/src/lib.rs
@@ -6,7 +6,7 @@
 #![feature(asm)]
 #![deny(missing_docs)]
 #![deny(clippy::all)]
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 //! The `proxy` module contains structures used to facilitate communication between
 //! the microkernel and the hypervisor. This is referred to as "proxying" in the

--- a/internal/shim-sev/src/hostcall.rs
+++ b/internal/shim-sev/src/hostcall.rs
@@ -69,7 +69,15 @@ impl<'a> HostCall<'a> {
     #[inline(always)]
     pub unsafe fn hostcall(&mut self) -> sallyport::Result {
         let mut port = Port::<u16>::new(SYSCALL_TRIGGER_PORT);
+
+        // prevent earlier writes from being moved beyond this point
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::Release);
+
         port.write(1);
+
+        // prevent earlier reads from being moved before this point
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::Acquire);
+
         self.0.msg.rep.into()
     }
 

--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -577,7 +577,7 @@ impl Handler {
         uts.version[..6].copy_from_slice(TrySigned::try_signed(b"#1 SMP").unwrap());
         uts.machine[..6].copy_from_slice(TrySigned::try_signed(b"x86_64").unwrap());
         unsafe {
-            (self.a as *mut libc::utsname).write_volatile(uts);
+            (self.a as *mut libc::utsname).write(uts);
         }
         Ok(0)
     }
@@ -650,7 +650,7 @@ impl Handler {
                 p.st_ctime_nsec = 0;
 
                 unsafe {
-                    (self.b as *mut libc::stat).write_volatile(p);
+                    (self.b as *mut libc::stat).write(p);
                 }
 
                 eprintln!("SC> fstat({}, {{st_dev=makedev(0, 0x19), st_ino=3, st_mode=S_IFIFO|0600,\

--- a/internal/shim-sgx/src/handler.rs
+++ b/internal/shim-sgx/src/handler.rs
@@ -73,7 +73,13 @@ impl<'a> Handler<'a> {
     unsafe fn proxy(&mut self, req: Request) -> sallyport::Result {
         self.block.msg.req = req;
 
+        // prevent earlier writes from being moved beyond this point
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::Release);
+
         let _ret = syscall(self.aex, self.ctx);
+
+        // prevent earlier reads from being moved before this point
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::Acquire);
 
         self.block.msg.rep.into()
     }

--- a/src/backend/kvm/vm/cpu.rs
+++ b/src/backend/kvm/vm/cpu.rs
@@ -123,12 +123,8 @@ impl Thread for Cpu {
                             };
 
                             let c = sallyport.cursor();
-                            let (_, buf) = unsafe {
-                                c.alloc::<MemInfo>(1)
-                                    .map_err(|_| anyhow!("Failed to allocate MemInfo in Block"))?
-                            };
-
-                            buf[0] = mem_info;
+                            c.write(&mem_info)
+                                .map_err(|_| anyhow!("Failed to allocate MemInfo in Block"))?;
 
                             let ok_result: [Register<usize>; 2] = [0.into(), 0.into()];
 

--- a/src/sallyport/mod.rs
+++ b/src/sallyport/mod.rs
@@ -174,7 +174,9 @@ impl Default for Block {
 impl Block {
     /// Returns the capacity of `Block.buf`
     pub const fn buf_capacity() -> usize {
-        512 * Page::size() - size_of::<Message>()
+        // FIXME: https://github.com/enarx/enarx-keepldr/issues/23
+        let page_num = if cfg!(test) { 1 } else { 512 };
+        page_num * Page::size() - size_of::<Message>()
     }
 
     /// Returns a Cursor for the Block
@@ -243,14 +245,12 @@ mod tests {
     }
 
     #[test]
-    // FIXME this should not be ignored, this was applied as part
-    // of a commit that must be reverted and implemented properly.
-    #[ignore]
     fn block_size() {
         assert_eq!(size_of::<Block>(), Page::size());
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn syscall() {
         // Test syscall failure, including bidirectional conversion.
         let req = request!(libc::SYS_close => -1isize);
@@ -305,9 +305,6 @@ mod tests {
     }
 
     #[test]
-    // FIXME this should not be ignored, this was applied as part
-    // of a commit that must be reverted and implemented properly.
-    #[ignore]
     fn cursor() {
         let mut block = Block::default();
 
@@ -323,9 +320,6 @@ mod tests {
     }
 
     #[test]
-    // FIXME this should not be ignored, this was applied as part
-    // of a commit that must be reverted and implemented properly.
-    #[ignore]
     fn cursor_multiple_allocs() {
         let mut block = Block::default();
 


### PR DESCRIPTION
* shims: Add a compiler memory fence for the host proxy calls

    To prevents the compiler from optimizing read and writes not knowing of
    the side-effects of the syscall, `core::sync::atomic::compiler_fence`
    is added before and after the host call via sallyport.
    
    Therefore this patch also changes the now unnecessary volatile
    writes into normal writes.
    
    Fixes: https://github.com/enarx/enarx-keepldr/issues/59   

* sallyport: Re-enable tests

    Re-enable the test suite by temporarily changing the
    `Block::buf_capacity` to `Page::size()` if tests are enabled,
    otherwise the tests will fail with a buffer overflow.
    
    Also ignore the `syscall` test for `cargo miri test`, because
    inline assembly is not supported for `miri`.

* sallyport: Extend `Cursor` with read/write convenience methods
    
    This patch extends the `Cursor` with read/write convenience
    methods for various use cases, refactoring some code and
    moving unsafe copy operations to a central place.
    
    Because most pointers don't have to be dereferenced,
    this prevents potential UB (undefined behaviour) usage.
    
    Related: https://github.com/enarx/enarx-keepldr/issues/78   

* sallyport: Return MaybeUninit for `Cursor::alloc()`
    
    let `Cursor::alloc()` return `&mut MaybeUninit<T>`
    instead of `&mut [T]` to indicate, that the buffer is uninitialized.

