### PR TITLE
Retain 'enarx-keepldr' as process name for nil keep

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -168,8 +168,17 @@ fn exec(backends: &[Box<dyn Backend>], opts: Exec) -> Result<()> {
         match keep {
             Some(name) if name != "nil" => panic!("Keep backend '{}' is unsupported.", name),
             _ => {
+                use std::env::args_os;
                 let cstr = CString::new(opts.code.as_os_str().as_bytes()).unwrap();
-                unsafe { libc::execl(cstr.as_ptr(), cstr.as_ptr(), null::<c_char>()) };
+                let name = CString::new(args_os().next().unwrap().as_os_str().as_bytes()).unwrap();
+                unsafe {
+                    libc::execl(
+                        cstr.as_ptr(),
+                        name.as_ptr(),
+                        cstr.as_ptr(),
+                        null::<c_char>(),
+                    )
+                };
                 return Err(Error::last_os_error().into());
             }
         }


### PR DESCRIPTION
Closes #63.

Before the patch:

    $ ps aux | grep enarx-keepldr
    // empty, aside from grep process

    $ ps aux | grep demo
    [..] /home/ckuehl/src/demo/target/debug/demo
    // have to grep for 'demo' as process name

After the patch:

    $ ps aux | grep enarx-keepldr
    [..] target/debug/enarx-keepldr /home/ckuehl/src/demo/target/debug/demo
    // grepping for 'enarx-keepldr' will find the process

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>
