### PR TITLE
tests: use `process_control` to wait with timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,10 +203,10 @@ dependencies = [
  "mmarinus",
  "nbytes",
  "primordial",
+ "process_control",
  "sev",
  "sgx",
  "structopt",
- "wait-timeout",
  "walkdir",
  "x86_64",
 ]
@@ -413,6 +413,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "process_control"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467104c6d75c2a82ff09ee57a3e2f19a30aa986f6601fc5b9967987a38b10f02"
+dependencies = [
+ "cc",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,15 +623,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183d25b56a61a6f518ef464ac578e790f04added34dfaab59a453d8a03cb7bd0"
 dependencies = [
  "bitflags",
- "libc",
-]
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,4 @@ cc = "1.0"
 walkdir = "2"
 
 [dev-dependencies]
-wait-timeout = "0.2"
+process_control = "2.0"


### PR DESCRIPTION
The `process_control` crate allows to get the output while waiting.

Otherwise the child stderr/stderr buffers may fillup, the test process
would block, and will finally be killed by `run_test()`.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!-- 
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #123" or "Resolves enarx/repo-name#123", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
