### PR TITLE
Added enarx/bot status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![lint](https://github.com/enarx/enarx-keepldr/workflows/lint/badge.svg)
+![enarxbot](https://github.com/enarx/enarx-keepldr/workflows/enarxbot/badge.svg)
 [![Workflow Status](https://github.com/enarx/enarx-keepldr/workflows/test/badge.svg)](https://github.com/enarx/enarx-keepldr/actions?query=workflow%3A%22test%22)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/enarx/enarx-keepldr.svg)](https://isitmaintained.com/project/enarx/enarx-keepldr "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/enarx/enarx-keepldr.svg)](https://isitmaintained.com/project/enarx/enarx-keepldr "Percentage of issues still open")

--- a/README.tpl
+++ b/README.tpl
@@ -1,0 +1,9 @@
+![lint](https://github.com/enarx/enarx-keepldr/workflows/lint/badge.svg)
+![enarxbot](https://github.com/enarx/enarx-keepldr/workflows/enarxbot/badge.svg)
+{{badges}}
+
+# {{crate}}
+
+{{readme}}
+
+License: {{license}}


### PR DESCRIPTION
Closes #85 

Added a badge to the README to reflect the status of enarx/bot

<!-- 
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #xyz" or "Resolves enarx/repo-name#xyz", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
