### PR TITLE
Preparatory work for management by enarx-keepmgr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ anyhow = "1.0"
 goblin = "0.2"
 libc = "0.2"
 lset = "0.1"
+uuid =  { version = "0.8", features = ["serde", "v4"] }#
 
 [build-dependencies]
 cc = "1.0"

--- a/README.md
+++ b/README.md
@@ -78,4 +78,14 @@ Or specific backends can be compiled in:
 
     $ cargo build --features=backend-sgx,backend-kvm
 
+## Launch via systemd (not yet fully working)
+  - This is for testing on a (possibly shared) system
+
+    Copy (or link) the files in external/*.service to ~/.config/systemd/user/
+    $ systemctl --user daemon-reload
+    $ systemctl --user start enarx-keep-nil@[Uuid].service
+
+Output will go to journalctl and console: edit the files in
+ enarx-keepldr/external to change
+
 License: Apache-2.0

--- a/external/enarx-keep-kvm@.service
+++ b/external/enarx-keep-kvm@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Enarx Keep-Loader (KVM)
+Documentation=https://github.com/enarx/
+
+[Service]
+Type=simple
+Environment="ENARX_BACKEND=kvm"
+ExecStart=/home/mike/programming/enarx-keepldr/target/debug/enarx-keepldr kuuid I%
+
+UMask=0066
+
+StandardOutput=file:/home/mike/enarx-keepldr-%i.log
+StandardError=file:/home/mike/enarx-keepldr-%i.err
+

--- a/external/enarx-keep-kvm@.service
+++ b/external/enarx-keep-kvm@.service
@@ -9,6 +9,6 @@ ExecStart=/home/mike/programming/enarx-keepldr/target/debug/enarx-keepldr kuuid 
 
 UMask=0066
 
-StandardOutput=file:/home/mike/enarx-keepldr-%i.log
-StandardError=file:/home/mike/enarx-keepldr-%i.err
+StandardOutput=journal+console
+StandardError=journal+console
 

--- a/external/enarx-keep-nil@.service
+++ b/external/enarx-keep-nil@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Enarx Keep-Loader (Nil)
+Documentation=https://github.com/enarx/
+
+[Service]
+Type=simple
+Environment="ENARX_BACKEND=nil"
+ExecStart=/home/mike/programming/enarx-keepldr/target/debug/enarx-keepldr kuuid I%
+
+UMask=0066
+
+StandardOutput=file:/home/mike/enarx-keepldr-%i.log
+StandardError=file:/home/mike/enarx-keepldr-%i.err
+

--- a/external/enarx-keep-nil@.service
+++ b/external/enarx-keep-nil@.service
@@ -9,6 +9,6 @@ ExecStart=/home/mike/programming/enarx-keepldr/target/debug/enarx-keepldr kuuid 
 
 UMask=0066
 
-StandardOutput=file:/home/mike/enarx-keepldr-%i.log
-StandardError=file:/home/mike/enarx-keepldr-%i.err
+StandardOutput=journal+console
+StandardError=journal+console
 

--- a/external/enarx-keep-sev@.service
+++ b/external/enarx-keep-sev@.service
@@ -9,6 +9,6 @@ ExecStart=/home/mike/programming/enarx-keepldr/target/debug/enarx-keepldr kuuid 
 
 UMask=0066
 
-StandardOutput=file:/home/mike/enarx-keepldr-%i.log
-StandardError=file:/home/mike/enarx-keepldr-%i.err
+StandardOutput=journal+console
+StandardError=journal+console
 

--- a/external/enarx-keep-sev@.service
+++ b/external/enarx-keep-sev@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Enarx Keep-Loader (SEV)
+Documentation=https://github.com/enarx/
+
+[Service]
+Type=simple
+Environment="ENARX_BACKEND=sev"
+ExecStart=/home/mike/programming/enarx-keepldr/target/debug/enarx-keepldr kuuid I%
+
+UMask=0066
+
+StandardOutput=file:/home/mike/enarx-keepldr-%i.log
+StandardError=file:/home/mike/enarx-keepldr-%i.err
+

--- a/external/enarx-keep-sgx@.service
+++ b/external/enarx-keep-sgx@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Enarx Keep-Loader (SGX)
+Documentation=https://github.com/enarx/
+
+[Service]
+Type=simple
+Environment="ENARX_BACKEND=sgx"
+ExecStart=/home/mike/programming/enarx-keepldr/target/debug/enarx-keepldr kuuid I%
+
+UMask=0066
+
+StandardOutput=file:/home/mike/enarx-keepldr-%i.log
+StandardError=file:/home/mike/enarx-keepldr-%i.err
+

--- a/external/enarx-keep-sgx@.service
+++ b/external/enarx-keep-sgx@.service
@@ -9,6 +9,6 @@ ExecStart=/home/mike/programming/enarx-keepldr/target/debug/enarx-keepldr kuuid 
 
 UMask=0066
 
-StandardOutput=file:/home/mike/enarx-keepldr-%i.log
-StandardError=file:/home/mike/enarx-keepldr-%i.err
+StandardOutput=journal+console
+StandardError=journal+console
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,13 @@
 //! Or specific backends can be compiled in:
 //!
 //!     $ cargo build --features=backend-sgx,backend-kvm
+//!
+//! #Launch via systemd (not yet fully working)
+//!   - This is for testing on a (possibly shared) system
+//!
+//!     Copy (or link) the files in external/*.service to ~/.config/systemd/user/
+//!     $ systemctl --user daemon-reload
+//!     $ systemctl --user start enarx-keep-nil@[Uuid].service
 
 #![deny(clippy::all)]
 #![deny(missing_docs)]
@@ -95,6 +102,8 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 use std::ptr::null;
 
+use uuid::Uuid;
+
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
 
@@ -113,11 +122,19 @@ struct Exec {
     code: PathBuf,
 }
 
+/// Takes a kuuid and then executes
+#[derive(StructOpt)]
+struct Kuuid {
+    /// The Kuuid
+    kuuid: Uuid,
+}
+
 #[derive(StructOpt)]
 #[structopt(version=VERSION, author=AUTHORS.split(";").nth(0).unwrap())]
 enum Options {
     Info(Info),
     Exec(Exec),
+    Kuuid(Kuuid),
 }
 
 fn main() -> Result<()> {
@@ -133,6 +150,7 @@ fn main() -> Result<()> {
     match Options::from_args() {
         Options::Info(_) => info(backends),
         Options::Exec(e) => exec(backends, e),
+        Options::Kuuid(k) => kuuid(backends, k),
     }
 }
 
@@ -164,6 +182,13 @@ fn info(backends: &[Box<dyn Backend>]) -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+fn kuuid(_backends: &[Box<dyn Backend>], kuuid: Kuuid) -> Result<()> {
+    //currently a stub
+    //TODO - add execution
+    println!("Kuuid received {:?}", kuuid.kuuid);
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@
 //!
 //!     $ cargo build --features=backend-sgx,backend-kvm
 //!
-//! #Launch via systemd (not yet fully working)
+//! # Launch via systemd (not yet fully working)
 //!   - This is for testing on a (possibly shared) system
 //!
 //!     Copy (or link) the files in external/*.service to ~/.config/systemd/user/

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,9 @@
 //!     Copy (or link) the files in external/*.service to ~/.config/systemd/user/
 //!     $ systemctl --user daemon-reload
 //!     $ systemctl --user start enarx-keep-nil@[Uuid].service
+//!
+//! Output will go to journalctl and console: edit the files in
+//!  enarx-keepldr/external to change
 
 #![deny(clippy::all)]
 #![deny(missing_docs)]


### PR DESCRIPTION
Currently doesn't actually spawn a keep.
Needs to create Unix socket and communicate with enarx-keepmgr.

Signed-off-by: MikeCamel <mike@p2ptrust.org>
