### PR TITLE
shim-sev:syscall: swapgs at end of syscall

### DIFF
--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -42,7 +42,6 @@ pub unsafe fn _syscall_enter() -> ! {
     push   r11                                        # push RFLAGS stored in r11
     push   {3}
     push   rcx                                        # push userspace return pointer
-    swapgs                                            # restore gs
 
     # Arguments in registers:
     # SYSV:    rdi, rsi, rdx, rcx, r8, r9
@@ -76,6 +75,8 @@ pub unsafe fn _syscall_enter() -> ! {
     pop    rdx
     pop    rsi
     pop    rdi
+
+    swapgs                                            # restore gs
 
     iretq
     ",


### PR DESCRIPTION
Swap the `gs` register back to user space `gs` _after_ the kernel
handled the syscall.

Later `gs` can be used for other purposes in the kernel, so this
prevents future usage to clobber userspace `gs` in any way.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
