### PR TITLE
-static-pie was not an option for musl, but -static and -pie were. Is this just on my system (4.15.0-122-generic #124-Ubuntu SMP Thu Oct 15 13:03:05 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ technologies such as Intel SGX or AMD SEV.
     }
     EOF
 
-    $ musl-gcc -static-pie -fPIC -o test test.c
+    $ musl-gcc -static -pie -fPIC -o test test.c
     $ target/debug/enarx-keepldr exec ./test
     Hello World!
 

--- a/build.rs
+++ b/build.rs
@@ -93,7 +93,8 @@ fn build_cc_tests(in_path: &Path, out_path: &Path) {
         let status = cmd
             .current_dir(&out_path)
             .arg("-nostdlib")
-            .arg("-static-pie")
+            .arg("-static")
+	    .arg("-pie")
             .arg("-fPIC")
             .arg("-o")
             .arg(output)


### PR DESCRIPTION
<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
