### PR TITLE
Remove __thread storage class from errnum

### DIFF
--- a/tests/bin/libc.h
+++ b/tests/bin/libc.h
@@ -5,7 +5,7 @@
 #include <time.h>
 
 int *__errno_location(void) {
-    static __thread int errnum = 0;
+    static int errnum = 0;
     return &errnum;
 }
 


### PR DESCRIPTION
Otherwise we segfault when we access it for some reason...

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>
