### PR TITLE
shim-sev:build.rs: remove problematic opt flag

### DIFF
--- a/internal/shim-sev/build.rs
+++ b/internal/shim-sev/build.rs
@@ -36,8 +36,6 @@ fn main() {
         .no_default_flags(true)
         .flag("-O2")
         .flag(debug_flag)
-        // Optimize for AMD Zen 2
-        .flag("-mtune=znver2")
         .files(&entries)
         .static_flag(true)
         .shared_flag(false)


### PR DESCRIPTION
According to
https://github.com/enarx/enarx-keepldr/pull/102#issuecomment-714803978
the `-mtune=znver2` switch requires a backported patch. Because this
optimization flag is not really needed, just remove it.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
