### PR TITLE
shim-sev: handle multiple return values for syscalls

### DIFF
--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -29,6 +29,15 @@ const FAKE_GID: usize = 1000;
 #[inline(never)]
 #[naked]
 pub unsafe fn _syscall_enter() -> ! {
+    let rdi: usize;
+    let rsi: usize;
+    let rdx: usize;
+    let r10: usize;
+    let r8: usize;
+    let r9: usize;
+    let nr: usize;
+    let rbx: usize;
+
     use crate::gdt::{USER_CODE_SEGMENT, USER_DATA_SEGMENT};
     // TaskStateSegment.privilege_stack_table[0]
     const KERNEL_RSP_OFF: usize = size_of::<u32>();
@@ -47,64 +56,79 @@ pub unsafe fn _syscall_enter() -> ! {
     push   {3}
     push   rcx                                        # push userspace return pointer
 
-    # Arguments in registers:
-    # SYSV:    rdi, rsi, rdx, rcx, r8, r9
-    # SYSCALL: rdi, rsi, rdx, r10, r8, r9 and syscall number in rax
-    mov    rcx,                     r10
-
-    # save registers
+    push   rbx
     push   rdi
     push   rsi
-    push   rdx
     push   rcx
     push   r11
     push   r10
     push   r8
     push   r9
-
-    # syscall number on the stack as the seventh argument
-    push   rax
-
-    call   {4}
-
-    # skip %rax pop, as it is the return value
-    add    rsp,                     0x8
-
-    # restore registers
-    pop    r9
-    pop    r8
-    pop    r10
-    pop    r11
-    pop    rcx
-    pop    rdx
-    pop    rsi
-    pop    rdi
-
-    swapgs                                            # restore gs
-
-    iretq
+    mov    rbx, rsp                                   # save the actual stack pointer
     ",
     const USR_RSP_OFF,
     const KERNEL_RSP_OFF,
     const USER_DATA_SEGMENT,
     const USER_CODE_SEGMENT,
-    sym syscall_rust,
-    options(noreturn)
     );
+
+    // In non optlevel reserve some redzone stack space
+    #[cfg(debug_assertions)]
+    asm!("sub rsp, 0x198");
+
+    asm!("",
+    lateout("rdi") rdi,
+    lateout("rsi") rsi,
+    lateout("rdx") rdx,
+    lateout("r10") r10,
+    lateout("r8") r8,
+    lateout("r9") r9,
+    lateout("rax") nr,
+    lateout("rbx") rbx,
+    options(pure, nomem, nostack)
+    );
+
+    // Arguments in registers:
+    // SYSCALL: rdi, rsi, rdx, r10, r8, r9 and syscall number in rax
+
+    let (rax, rdx) = syscall_rust(rdi, rsi, rdx, r10, r8, r9, nr);
+
+    asm!("
+    mov    rsp, rbx                                   # restore the stack pointer
+    pop    r9
+    pop    r8
+    pop    r10
+    pop    r11
+    pop    rcx
+    pop    rsi
+    pop    rdi
+    pop    rbx
+
+    swapgs                                            # restore gs
+
+    iretq
+    ", in("rbx") rbx, in("rax") rax, in("rdx") rdx, options(noreturn, nomem));
 }
 
+/// Handle a syscall in rust
 #[allow(clippy::many_single_char_names)]
 #[no_mangle]
-/// Handle a syscall in rust
-pub extern "C" fn syscall_rust(
-    a: Register<usize>,
-    b: Register<usize>,
-    c: Register<usize>,
-    d: Register<usize>,
-    e: Register<usize>,
-    f: Register<usize>,
+pub fn syscall_rust(
+    a: usize,
+    b: usize,
+    c: usize,
+    d: usize,
+    e: usize,
+    f: usize,
     nr: usize,
-) -> usize {
+) -> (usize, usize) {
+    let orig_rdx = c;
+    let a: Register<usize> = a.into();
+    let b: Register<usize> = b.into();
+    let c: Register<usize> = c.into();
+    let d: Register<usize> = d.into();
+    let e: Register<usize> = e.into();
+    let f: Register<usize> = f.into();
     /*
     #[cfg(debug_assertions)]
     eprintln!(
@@ -168,11 +192,24 @@ pub extern "C" fn syscall_rust(
         }
     };
 
-    let res = do_syscall().unwrap_or_else(|e| e.checked_neg().unwrap() as usize) as usize;
+    if nr >= 0xEA00 {
+        // Enarx syscalls
 
-    #[cfg(debug_assertions)]
-    eprintln!("SC> = {:#x}", res);
-    res
+        // Fixme
+        let ret: sallyport::Result = Err(libc::ENOSYS);
+
+        match ret {
+            Err(e) => (e.checked_neg().unwrap() as usize, orig_rdx),
+            Ok([rax, rdx]) => (rax.into(), rdx.into()),
+        }
+    } else {
+        let res = do_syscall().unwrap_or_else(|e| e.checked_neg().unwrap() as usize) as usize;
+
+        #[cfg(debug_assertions)]
+        eprintln!("SC> = {:#x}", res);
+        // Preserve `rdx` as it is normally not clobbered with a syscall
+        (res, orig_rdx)
+    }
 }
 
 /// syscall


### PR DESCRIPTION
`rdx` is sometimes used as a secondary return value.

Because `rdx` is not marked as `clobber` for the musl syscall macro,
the original value has to be returned, if `rdx` is unused as a return
value.

To combat the use of the stack in `_syscall_enter` with `opt-level=0`,
reserve a little red zone on the stack for `#[cfg(debug_assertions)]`.
In `opt-level=3` the compiler does emit the correct assembly code
without using the stack.

This patch also adds a dummy path for the enarx syscalls, which can make
use of the second return value.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
