### PR TITLE
sallyport: syscall clobber `rcx` and `r11`

### DIFF
--- a/src/sallyport/mod.rs
+++ b/src/sallyport/mod.rs
@@ -67,6 +67,8 @@ impl Request {
             in("r10") usize::from(self.arg[3]),
             in("r8") usize::from(self.arg[4]),
             in("r9") usize::from(self.arg[5]),
+            lateout("rcx") _, // clobbered
+            lateout("r11") _, // clobbered
         );
 
         Reply {


### PR DESCRIPTION
A syscall clobbers `rcx` and `r11`, which was not marked here.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
