### PR TITLE
sallyport: mark Cursor::alloc as safe

### DIFF
--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -230,7 +230,7 @@ fn _read(fd: libc::c_int, trusted: *mut u8, trusted_len: usize) -> Result<usize,
     let block = host_call.as_mut_block();
 
     let c = block.cursor();
-    let (_, buf) = unsafe { c.alloc::<u8>(trusted_len).or(Err(libc::EMSGSIZE))? };
+    let (_, buf) = c.alloc::<u8>(trusted_len).or(Err(libc::EMSGSIZE))?;
 
     let host_virt = blk_to_host_virt(buf.as_ptr());
 
@@ -645,7 +645,7 @@ pub fn clock_gettime(
     let block = host_call.as_mut_block();
 
     let c = block.cursor();
-    let (_, buf) = unsafe { c.alloc::<libc::timespec>(1).or(Err(libc::EMSGSIZE))? };
+    let (_, buf) = c.alloc::<libc::timespec>(1).or(Err(libc::EMSGSIZE))?;
 
     let host_virt = blk_to_host_virt(buf.as_ptr());
 

--- a/internal/shim-sgx/src/handler.rs
+++ b/internal/shim-sgx/src/handler.rs
@@ -216,7 +216,7 @@ impl<'a> Handler<'a> {
         let c = self.block.cursor();
         let trusted_len: usize = self.aex.gpr.rdx.into();
         let trusted: *mut u8 = self.aex.gpr.rsi.into();
-        let (_, untrusted) = unsafe { c.alloc::<u8>(trusted_len).or(Err(libc::EMSGSIZE))? };
+        let (_, untrusted) = c.alloc::<u8>(trusted_len).or(Err(libc::EMSGSIZE))?;
 
         let req = request!(libc::SYS_read => self.aex.gpr.rdi, untrusted, untrusted.len());
         let ret = unsafe { self.proxy(req)? };
@@ -291,7 +291,7 @@ impl<'a> Handler<'a> {
 
         let mut c = c;
         for (t, u) in trusted.iter_mut().zip(untrusted.iter_mut()) {
-            let (nc, us) = unsafe { c.alloc::<u8>(t.iov_len).or(Err(libc::EMSGSIZE))? };
+            let (nc, us) = c.alloc::<u8>(t.iov_len).or(Err(libc::EMSGSIZE))?;
             c = nc;
             u.iov_base = us.as_mut_ptr() as _;
             size += u.iov_len;
@@ -306,7 +306,9 @@ impl<'a> Handler<'a> {
         }
 
         let c = self.block.cursor();
-        let (c, _) = unsafe { c.alloc::<libc::iovec>(trusted.len()) }.or(Err(libc::EMSGSIZE))?;
+        let (c, _) = c
+            .alloc::<libc::iovec>(trusted.len())
+            .or(Err(libc::EMSGSIZE))?;
 
         let mut c = c;
         for t in trusted.iter_mut() {
@@ -513,7 +515,7 @@ impl<'a> Handler<'a> {
         let trusted = NonNull::<libc::timespec>::new(trusted).ok_or(libc::EFAULT)?;
 
         let c = self.block.cursor();
-        let (_, untrusted) = unsafe { c.alloc::<libc::timespec>(1).or(Err(libc::EMSGSIZE))? };
+        let (_, untrusted) = c.alloc::<libc::timespec>(1).or(Err(libc::EMSGSIZE))?;
         let req = request!(libc::SYS_clock_gettime => clk_id, untrusted);
         let res = unsafe { self.proxy(req)? };
 

--- a/src/sallyport/mod.rs
+++ b/src/sallyport/mod.rs
@@ -200,16 +200,12 @@ pub struct OutOfSpace;
 
 impl<'a> Cursor<'a> {
     /// Allocates an array, containing count number of T items. The result is uninitialized.
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe because it returns an uninitialized array.
-    pub unsafe fn alloc<T>(
+    pub fn alloc<T>(
         self,
         count: usize,
     ) -> core::result::Result<(Cursor<'a>, &'a mut [MaybeUninit<T>]), OutOfSpace> {
         let mid = {
-            let (padding, data, _) = self.0.align_to_mut::<MaybeUninit<T>>();
+            let (padding, data, _) = unsafe { self.0.align_to_mut::<MaybeUninit<T>>() };
 
             if data.len() < count {
                 return Err(OutOfSpace);
@@ -220,7 +216,10 @@ impl<'a> Cursor<'a> {
 
         let (data, next) = self.0.split_at_mut(mid);
 
-        Ok((Cursor(next), data.align_to_mut::<MaybeUninit<T>>().1))
+        Ok((
+            Cursor(next),
+            unsafe { data.align_to_mut::<MaybeUninit<T>>() }.1,
+        ))
     }
 
     /// Copies data from a slice into the cursor buffer using self.alloc().
@@ -229,7 +228,7 @@ impl<'a> Cursor<'a> {
         self,
         src: &[T],
     ) -> core::result::Result<(Cursor<'a>, &'a mut [T]), OutOfSpace> {
-        let (c, dst) = unsafe { self.alloc::<T>(src.len())? };
+        let (c, dst) = self.alloc::<T>(src.len())?;
 
         unsafe {
             core::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr() as _, src.len());
@@ -294,7 +293,7 @@ impl<'a> Cursor<'a> {
     /// Writes data into the cursor buffer.
     #[allow(dead_code)]
     pub fn write<T: 'a + Copy>(self, src: &T) -> core::result::Result<Cursor<'a>, OutOfSpace> {
-        let (c, dst) = unsafe { self.alloc::<T>(1)? };
+        let (c, dst) = self.alloc::<T>(1)?;
 
         unsafe {
             core::ptr::write(dst[0].as_mut_ptr(), *src);
@@ -405,10 +404,10 @@ mod tests {
         let mut block = Block::default();
 
         let c = block.cursor();
-        assert!(unsafe { c.alloc::<usize>(4096usize).is_err() });
+        assert!(c.alloc::<usize>(4096usize).is_err());
 
         let c = block.cursor();
-        assert_eq!(unsafe { c.alloc::<usize>(42usize) }.unwrap().1.len(), 42);
+        assert_eq!(c.alloc::<usize>(42usize).unwrap().1.len(), 42);
 
         let c = block.cursor();
         let (_c, slice) = c.copy_from_slice(&[87, 2, 3]).unwrap();
@@ -437,10 +436,9 @@ mod tests {
         assert_eq!(slab3, &[5, 6]);
 
         let c = block.cursor();
-        let (_c, slab_all) = unsafe {
-            c.alloc::<usize>(6)
-                .expect("re-allocate slab of 6 usize values already initialized")
-        };
+        let (_c, slab_all) = c
+            .alloc::<usize>(6)
+            .expect("re-allocate slab of 6 usize values already initialized");
 
         // Assume init
         let slab_all: &mut [usize] = unsafe { &mut *(slab_all as *mut _ as *mut [_]) };


### PR DESCRIPTION
Because `Cursor::alloc()` returns a `MaybeUninit` it can be marked as safe.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
