### PR TITLE
sallyport: add `Cursor::copy_into_slice()`

### DIFF
--- a/src/sallyport/mod.rs
+++ b/src/sallyport/mod.rs
@@ -241,6 +241,26 @@ impl<'short, 'a: 'short> Cursor<'a> {
         Ok((c, dst))
     }
 
+    /// Copies data from a slice into the cursor buffer using self.alloc().
+    #[allow(dead_code)]
+    pub fn copy_into_slice<T: Copy>(
+        self,
+        src_len: usize,
+        dst: &mut [T],
+        dst_len: usize,
+    ) -> core::result::Result<Cursor<'a>, OutOfSpace> {
+        assert!(src_len >= dst_len);
+        assert!(dst.len() >= dst_len);
+
+        let (c, src) = self.alloc::<T>(src_len)?;
+
+        unsafe {
+            core::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr() as _, dst_len);
+        }
+
+        Ok(c)
+    }
+
     /// Copies data from a raw slice pointer into the cursor buffer using self.alloc().
     ///
     /// The len argument is the number of **elements**, not the number of bytes.

--- a/src/sallyport/mod.rs
+++ b/src/sallyport/mod.rs
@@ -200,12 +200,12 @@ pub struct Cursor<'a>(&'a mut [u8]);
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct OutOfSpace;
 
-impl<'a> Cursor<'a> {
+impl<'short, 'a: 'short> Cursor<'a> {
     /// Allocates an array, containing count number of T items. The result is uninitialized.
     pub fn alloc<T>(
         self,
         count: usize,
-    ) -> core::result::Result<(Cursor<'a>, &'a mut [MaybeUninit<T>]), OutOfSpace> {
+    ) -> core::result::Result<(Cursor<'a>, &'short mut [MaybeUninit<T>]), OutOfSpace> {
         let mid = {
             let (padding, data, _) = unsafe { self.0.align_to_mut::<MaybeUninit<T>>() };
 
@@ -229,7 +229,7 @@ impl<'a> Cursor<'a> {
     pub fn copy_from_slice<T: 'a + Copy>(
         self,
         src: &[T],
-    ) -> core::result::Result<(Cursor<'a>, &'a mut [T]), OutOfSpace> {
+    ) -> core::result::Result<(Cursor<'a>, &'short mut [T]), OutOfSpace> {
         let (c, dst) = self.alloc::<T>(src.len())?;
 
         unsafe {


### PR DESCRIPTION
* sallyport: add `Cursor::copy_into_slice()`

    This actually needs a decouple of lifetimes of `Cursor::alloc()`.

*  sallyport: give some return values a decoupled lifetime
    
    Sometimes the lifetime of a return value has to be decoupled from the
    parent object with a short lifetime.
    
    Here `Cursor::alloc` and `Cursor::copy_from_slice` benefit from
    returning references with a possible shorter lifetime than the original
    `Cursor`.
    
    Signed-off-by: Harald Hoyer <harald@redhat.com>
