### PR TITLE
shims: Unify syscall handlers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
   schedule:
     interval: "daily"
 - package-ecosystem: "cargo"
+  directory: "internal/untrusted"
+  schedule:
+    interval: "daily"
+- package-ecosystem: "cargo"
   directory: "internal/sgx-heap"
   schedule:
     interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
   schedule:
     interval: "daily"
 - package-ecosystem: "cargo"
+  directory: "internal/syscall"
+  schedule:
+    interval: "daily"
+- package-ecosystem: "cargo"
   directory: "internal/sgx-heap"
   schedule:
     interval: "daily"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,7 @@ jobs:
           - {name: sgx-heap, path: internal/sgx-heap/Cargo.toml}
           - {name: sallyport, path: internal/sallyport/Cargo.toml}
           - {name: untrusted, path: internal/untrusted/Cargo.toml}
+          - {name: syscall, path: internal/syscall/Cargo.toml}
           - {name: shim-sgx, path: internal/shim-sgx/Cargo.toml}
           - {name: shim-sev, path: internal/shim-sev/Cargo.toml}
 
@@ -53,6 +54,7 @@ jobs:
           - {name: enarx-keepldr, path: Cargo.toml}
           - {name: sallyport, path: internal/sallyport/Cargo.toml}
           - {name: untrusted, path: internal/untrusted/Cargo.toml}
+          - {name: syscall, path: internal/syscall/Cargo.toml}
           - {name: sgx-heap, path: internal/sgx-heap/Cargo.toml}
           - name: rcrt1
             path: internal/rcrt1/Cargo.toml
@@ -94,5 +96,6 @@ jobs:
           - {name: sgx-heap, path: internal/sgx-heap/Cargo.toml}
           - {name: sallyport, path: internal/sallyport/Cargo.toml}
           - {name: untrusted, path: internal/untrusted/Cargo.toml}
+          - {name: syscall, path: internal/syscall/Cargo.toml}
           - {name: shim-sgx, path: internal/shim-sgx/Cargo.toml}
           - {name: shim-sev, path: internal/shim-sev/Cargo.toml}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,7 @@ jobs:
           - {name: rcrt1, path: internal/rcrt1/Cargo.toml}
           - {name: sgx-heap, path: internal/sgx-heap/Cargo.toml}
           - {name: sallyport, path: internal/sallyport/Cargo.toml}
+          - {name: untrusted, path: internal/untrusted/Cargo.toml}
           - {name: shim-sgx, path: internal/shim-sgx/Cargo.toml}
           - {name: shim-sev, path: internal/shim-sev/Cargo.toml}
 
@@ -51,6 +52,7 @@ jobs:
         crate:
           - {name: enarx-keepldr, path: Cargo.toml}
           - {name: sallyport, path: internal/sallyport/Cargo.toml}
+          - {name: untrusted, path: internal/untrusted/Cargo.toml}
           - {name: sgx-heap, path: internal/sgx-heap/Cargo.toml}
           - name: rcrt1
             path: internal/rcrt1/Cargo.toml
@@ -91,5 +93,6 @@ jobs:
           - {name: rcrt1, path: internal/rcrt1/Cargo.toml}
           - {name: sgx-heap, path: internal/sgx-heap/Cargo.toml}
           - {name: sallyport, path: internal/sallyport/Cargo.toml}
+          - {name: untrusted, path: internal/untrusted/Cargo.toml}
           - {name: shim-sgx, path: internal/shim-sgx/Cargo.toml}
           - {name: shim-sev, path: internal/shim-sev/Cargo.toml}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
           - rcrt1
           - sgx-heap
           - sallyport
+          - untrusted
           - shim-sgx
           - shim-sev
         profile:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
           - sgx-heap
           - sallyport
           - untrusted
+          - syscall
           - shim-sgx
           - shim-sev
         profile:

--- a/internal/shim-sev/Cargo.lock
+++ b/internal/shim-sev/Cargo.lock
@@ -138,6 +138,8 @@ dependencies = [
  "rcrt1",
  "sallyport",
  "spinning",
+ "syscall",
+ "untrusted",
  "walkdir",
  "x86_64",
 ]
@@ -149,6 +151,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced8156fe289bee8576050d3924fe6f3926b552b41afe810f5461acaca42c9f1"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "syscall"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "primordial",
+ "sallyport",
+ "untrusted",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.1.0"
+dependencies = [
+ "primordial",
 ]
 
 [[package]]

--- a/internal/shim-sev/Cargo.toml
+++ b/internal/shim-sev/Cargo.toml
@@ -12,6 +12,8 @@ test = false
 [dependencies]
 sallyport = { path = "../sallyport", default-features = false }
 rcrt1 = { path = "../rcrt1" }
+untrusted = { path = "../untrusted"}
+syscall = { path = "../syscall"}
 compiler_builtins = { version = "0.1", default-features = false, features = [ "mem" ] }
 x86_64 = { version = "0.12", default-features = false, features = ["instructions", "inline_asm"] }
 goblin = { version = "0.2", default-features = false, features = [ "elf64" ] }

--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -3,27 +3,23 @@
 //! syscall interface layer between assembler and rust
 
 use crate::addr::{HostVirtAddr, ShimPhysUnencryptedAddr};
+use crate::asm::_enarx_asm_triple_fault;
 use crate::eprintln;
 use crate::frame_allocator::FRAME_ALLOCATOR;
-use crate::hostcall::{self, shim_write_all, HostFd, HOST_CALL};
+use crate::hostcall::{self, HostCall, HOST_CALL};
 use crate::paging::SHIM_PAGETABLE;
 use crate::payload::{NEXT_BRK_RWLOCK, NEXT_MMAP_RWLOCK};
 use core::convert::TryFrom;
-use core::mem::{size_of, MaybeUninit};
+use core::mem::size_of;
 use core::ops::{Deref, DerefMut};
-use core::ptr::NonNull;
 use primordial::{Address, Register};
-use sallyport::request;
+use sallyport::{Cursor, Request};
+use spinning::MutexGuard;
+use syscall::{SyscallHandler, ARCH_GET_FS, ARCH_GET_GS, ARCH_SET_FS, ARCH_SET_GS, SEV_TECH};
+use untrusted::{AddressValidator, UntrustedRef};
 use x86_64::registers::wrfsbase;
 use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
 use x86_64::{align_up, VirtAddr};
-
-const FAKE_UID: usize = 1000;
-const FAKE_GID: usize = 1000;
-
-// See https://github.com/enarx/enarx-keepldr/issues/31
-const SEV_TECH: usize = 1;
-const SYS_GETATT: usize = 0xEA01;
 
 #[repr(C)]
 struct X8664DoubleReturn {
@@ -116,780 +112,293 @@ extern "sysv64" fn syscall_rust(
 ) -> X8664DoubleReturn {
     let orig_rdx: usize = c.into();
 
-    /*
-    #[cfg(debug_assertions)]
-    eprintln!(
-        "SC> raw: syscall({}, {:#x}, {:#x}, {:#x}, {}, {}, {:#x})",
-        nr,
-        usize::from(a),
-        usize::from(b),
-        usize::from(c),
-        usize::from(d),
-        usize::from(e),
-        usize::from(f)
-    );
-    */
-    let linux_syscall = || -> Result<usize, libc::c_int> {
-        match nr as _ {
-            libc::SYS_exit => exit(usize::from(a) as _),
-            libc::SYS_exit_group => exit_group(usize::from(a) as _),
-            libc::SYS_read => read(usize::from(a) as _, b.into(), c.into()),
-            libc::SYS_readv => unsafe { readv(usize::from(a) as _, b.into(), usize::from(c) as _) },
-            libc::SYS_write => unsafe { write(usize::from(a) as _, b.into(), c.into()) },
-            libc::SYS_writev => unsafe {
-                writev(usize::from(a) as _, b.into(), usize::from(c) as _)
-            },
-            libc::SYS_mmap => mmap(
-                a.into(),
-                b.into(),
-                usize::from(c) as _,
-                usize::from(d) as _,
-                usize::from(e) as _,
-                f.into(),
-            ),
-            libc::SYS_munmap => munmap(a.into(), b.into()),
-            libc::SYS_arch_prctl => arch_prctl(usize::from(a) as _, b.into()),
-            libc::SYS_set_tid_address => set_tid_address(a.into()),
-            libc::SYS_rt_sigaction => rt_sigaction(usize::from(a) as _, b.into(), c.into()),
-            libc::SYS_rt_sigprocmask => {
-                rt_sigprocmask(usize::from(a) as _, b.into(), c.into(), d.into())
-            }
-            libc::SYS_sigaltstack => sigaltstack(a.into(), b.into()),
-            libc::SYS_getrandom => unsafe { getrandom(a.into(), b.into(), usize::from(c) as _) },
-            libc::SYS_brk => brk(a.into()),
-            libc::SYS_ioctl => ioctl(usize::from(a) as _, b.into()),
-            libc::SYS_mprotect => mprotect(a.into(), b.into(), usize::from(c) as _),
-            libc::SYS_clock_gettime => clock_gettime(usize::from(a) as _, b.into()),
-            libc::SYS_uname => unsafe { uname(a.into()) },
-            libc::SYS_readlink => readlink(a.into(), b.into(), c.into()),
-            libc::SYS_fstat => unsafe { fstat(usize::from(a) as _, b.into()) },
-            libc::SYS_fcntl => fcntl(usize::from(a) as _, usize::from(b) as _),
-            libc::SYS_madvise => madvise(a.into(), b.into(), usize::from(c) as _),
-            libc::SYS_poll => unsafe { poll(a.into(), b.into(), usize::from(c) as _) },
-            libc::SYS_getuid => getuid(),
-            libc::SYS_getgid => getgid(),
-            libc::SYS_geteuid => geteuid(),
-            libc::SYS_getegid => getegid(),
-
-            syscall => {
-                //panic!("SC> unsupported syscall: {}", syscall);
-                eprintln!("SC> unsupported syscall: {}", syscall);
-                Err(libc::ENOSYS)
-            }
-        }
+    let mut h = Handler {
+        hostcall: None,
+        argv: [a.into(), b.into(), c.into(), d.into(), e.into(), f.into()],
     };
 
-    if nr >= 0xEA00 {
-        // Enarx syscalls
+    let ret = h.syscall(a, b, c, d, e, f, nr);
 
-        let ret: sallyport::Result = match nr {
-            SYS_GETATT => Ok([0.into(), SEV_TECH.into()]),
-            _ => Err(libc::ENOSYS),
-        };
-
-        match ret {
-            Ok([rax, rdx]) => X8664DoubleReturn {
-                rax: rax.into(),
-                rdx: rdx.into(),
-            },
-            Err(e) => X8664DoubleReturn {
-                rax: e.checked_neg().unwrap() as _,
-                rdx: orig_rdx as _,
-            },
-        }
-    } else {
-        let res = linux_syscall().unwrap_or_else(|e| e.checked_neg().unwrap() as usize) as usize;
-
-        #[cfg(debug_assertions)]
-        eprintln!("SC> = {:#x}", res);
-
-        // Preserve `rdx` as it is normally not clobbered with a syscall
-        X8664DoubleReturn {
-            rax: res as _,
+    match ret {
+        Err(e) => X8664DoubleReturn {
+            rax: e.checked_neg().unwrap() as _,
+            // Preserve `rdx` as it is normally not clobbered with a syscall
             rdx: orig_rdx as _,
+        },
+        Ok([rax, rdx]) => X8664DoubleReturn {
+            rax: rax.into(),
+            rdx: rdx.into(),
+        },
+    }
+}
+
+/// FIXME
+struct Handler {
+    hostcall: Option<MutexGuard<'static, HostCall<'static>>>,
+    argv: [usize; 6],
+}
+
+impl AddressValidator for Handler {
+    #[inline(always)]
+    fn validate_const_mem_fn(&self, _ptr: *const (), _size: usize) -> bool {
+        // FIXME: https://github.com/enarx/enarx/issues/630
+        true
+    }
+
+    #[inline(always)]
+    fn validate_mut_mem_fn(&self, _ptr: *mut (), _size: usize) -> bool {
+        // FIXME: https://github.com/enarx/enarx/issues/630
+        true
+    }
+}
+
+impl SyscallHandler for Handler {
+    unsafe fn proxy(&mut self, req: Request) -> sallyport::Result {
+        let block = self
+            .hostcall
+            .get_or_insert_with(|| HOST_CALL.try_lock().unwrap())
+            .as_mut_block();
+        block.msg.req = req;
+        self.hostcall
+            .get_or_insert_with(|| HOST_CALL.try_lock().unwrap())
+            .hostcall()
+    }
+
+    fn attacked(&mut self) -> ! {
+        // provoke triple fault, causing a VM shutdown
+        unsafe { _enarx_asm_triple_fault() };
+    }
+
+    fn translate_shim_to_host_addr<T>(&self, buf: *const T) -> *const T {
+        let buf_address = Address::from(buf);
+        let phys_unencrypted = ShimPhysUnencryptedAddr::try_from(buf_address).unwrap();
+        Register::<usize>::from(HostVirtAddr::from(phys_unencrypted)).into()
+    }
+
+    fn new_cursor(&mut self) -> Cursor {
+        self.hostcall
+            .get_or_insert_with(|| HOST_CALL.try_lock().unwrap())
+            .as_mut_block()
+            .cursor()
+    }
+
+    fn trace(&mut self, name: &str, argc: usize) {
+        eprint!("{}(", name);
+        for (i, arg) in self.argv[..argc].iter().copied().enumerate() {
+            let prefix = if i > 0 { ", " } else { "" };
+            eprint!("{}0x{:x}", prefix, arg);
         }
-    }
-}
 
-/// syscall
-pub fn exit(status: libc::c_int) -> ! {
-    eprintln!("SC> exit({})", status);
-    hostcall::shim_exit(status);
-}
-
-/// syscall
-pub fn exit_group(status: libc::c_int) -> ! {
-    eprintln!("SC> exit_group({})", status);
-    hostcall::shim_exit(status);
-}
-
-fn _read(fd: libc::c_int, trusted: *mut u8, trusted_len: usize) -> Result<usize, libc::c_int> {
-    let mut host_call = HOST_CALL.try_lock().ok_or(libc::EIO)?;
-
-    let block = host_call.as_mut_block();
-
-    let c = block.cursor();
-    let (_, buf) = c.alloc::<u8>(trusted_len).or(Err(libc::EMSGSIZE))?;
-
-    let host_virt = blk_to_host_virt(buf.as_ptr());
-
-    block.msg.req = request!(libc::SYS_read => fd, host_virt, trusted_len);
-    let result = unsafe { host_call.hostcall() };
-    let result_len: usize = result.map(|r| r[0].into())?;
-
-    if trusted_len < result_len {
-        panic!("syscall read buffer overflow");
+        eprintln!(")");
     }
 
-    let block = host_call.as_mut_block();
-    let c = block.cursor();
-    unsafe { c.copy_into_raw_parts(trusted_len, trusted, result_len) }.or(Err(libc::EFAULT))?;
-
-    Ok(result_len)
-}
-
-/// syscall
-pub fn read(fd: libc::c_int, buf: *mut u8, count: libc::size_t) -> Result<usize, libc::c_int> {
-    _read(fd, buf, count)
-}
-
-/// syscall
-///
-/// # Safety
-/// Unsafe, because it dereferences `iov`.
-pub unsafe fn readv(
-    fd: libc::c_int,
-    iov: *const libc::iovec,
-    iovcnt: libc::c_int,
-) -> Result<usize, libc::c_int> {
-    // FIXME: unsafe
-    let iovec = core::slice::from_raw_parts(iov, iovcnt as _);
-
-    // FIXME: this is not an ideal implementation of readv, but for the sake
-    // of simplicity this readv implementation behaves very much like how the
-    // Linux kernel would for a module that does not support readv, but does
-    // support read.
-    let mut read = 0usize;
-    for vec in iovec {
-        let r = _read(fd, vec.iov_base as _, vec.iov_len as _)?;
-        read = read.checked_add(r).unwrap();
+    fn get_attestation(&mut self) -> sallyport::Result {
+        self.trace("get_att", 0);
+        Ok([0.into(), SEV_TECH.into()])
     }
 
-    Ok(read)
-}
-
-/// syscall
-///
-/// # Safety
-/// The caller has to ensure `buf` points to valid memory.
-pub unsafe fn write(
-    fd: libc::c_int,
-    buf: *const u8,
-    count: libc::size_t,
-) -> Result<usize, libc::c_int> {
-    let mut host_call = HOST_CALL.try_lock().ok_or(libc::EIO)?;
-    let block = host_call.as_mut_block();
-    let c = block.cursor();
-
-    let (_, buf) = c.copy_from_raw_parts(buf, count).or(Err(libc::EMSGSIZE))?;
-
-    let host_virt = blk_to_host_virt(buf);
-
-    block.msg.req = request!(libc::SYS_write => fd, host_virt, count);
-
-    host_call.hostcall().map(|r| r[0].into())
-}
-
-/// syscall
-///
-/// # Safety
-/// The caller has to ensure `iov` and its contents points to valid memory.
-pub unsafe fn writev(
-    fd: libc::c_int,
-    iov: *const libc::iovec,
-    iovcnt: libc::c_int,
-) -> Result<usize, libc::c_int> {
-    let fd = HostFd::from_raw_fd(fd);
-    let iovec = core::slice::from_raw_parts(iov, iovcnt as _);
-
-    let bufsize = iovec
-        .iter()
-        .fold(0, |a: usize, e| a.checked_add(e.iov_len).unwrap());
-
-    for vec in iovec {
-        let data = core::slice::from_raw_parts(vec.iov_base as *const u8, vec.iov_len as usize);
-        // FIXME: allocate unencrypted pages
-        shim_write_all(fd, data)?;
+    fn exit(&mut self, status: i32) -> ! {
+        self.trace("exit", 1);
+        hostcall::shim_exit(status);
     }
-    Ok(bufsize)
-}
 
-/// syscall
-pub fn arch_prctl(code: libc::c_int, addr: libc::c_ulong) -> Result<usize, libc::c_int> {
-    const ARCH_SET_GS: libc::c_int = 0x1001;
-    const ARCH_SET_FS: libc::c_int = 0x1002;
-    const ARCH_GET_FS: libc::c_int = 0x1003;
-    const ARCH_GET_GS: libc::c_int = 0x1004;
+    fn exit_group(&mut self, status: i32) -> ! {
+        self.trace("exit_group", 1);
+        hostcall::shim_exit(status);
+    }
 
-    match code {
-        ARCH_SET_FS => {
-            unsafe {
-                wrfsbase(addr);
+    fn arch_prctl(&mut self, code: i32, addr: u64) -> sallyport::Result {
+        self.trace("arch_prctl", 2);
+        match code {
+            ARCH_SET_FS => {
+                unsafe {
+                    wrfsbase(addr);
+                }
+                eprintln!("SC> arch_prctl(ARCH_SET_FS, {:#x}) = 0", addr);
+                Ok(Default::default())
             }
-            eprintln!("SC> arch_prctl(ARCH_SET_FS, {:#x}) = 0", addr);
-            Ok(0)
-        }
-        ARCH_GET_FS => unimplemented!(),
-        ARCH_SET_GS => unimplemented!(),
-        ARCH_GET_GS => unimplemented!(),
-        x => {
-            eprintln!("SC> arch_prctl({:#x}, {:#x}) = -EINVAL", x, addr);
-            Err(libc::EINVAL)
+            ARCH_GET_FS => unimplemented!(),
+            ARCH_SET_GS => unimplemented!(),
+            ARCH_GET_GS => unimplemented!(),
+            x => {
+                eprintln!("SC> arch_prctl({:#x}, {:#x}) = -EINVAL", x, addr);
+                Err(libc::EINVAL)
+            }
         }
     }
-}
 
-/// syscall
-pub fn mprotect(
-    addr: *const u8,
-    len: libc::size_t,
-    prot: libc::c_int,
-) -> Result<usize, libc::c_int> {
-    use x86_64::structures::paging::mapper::Mapper;
+    fn mprotect(&mut self, addr: UntrustedRef<u8>, len: usize, prot: i32) -> sallyport::Result {
+        self.trace("mprotect", 3);
+        let addr = addr.as_ptr();
 
-    let mut flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+        use x86_64::structures::paging::mapper::Mapper;
 
-    if prot & libc::PROT_WRITE != 0 {
-        flags |= PageTableFlags::WRITABLE;
+        let mut flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+
+        if prot & libc::PROT_WRITE != 0 {
+            flags |= PageTableFlags::WRITABLE;
+        }
+
+        if prot & libc::PROT_EXEC == 0 {
+            flags |= PageTableFlags::NO_EXECUTE;
+        }
+
+        let mut page_table = SHIM_PAGETABLE.write();
+
+        let start_addr = VirtAddr::from_ptr(addr);
+        let start_page: Page = Page::containing_address(start_addr);
+        let end_page: Page = Page::containing_address(start_addr + len - 1u64);
+        let page_range = Page::range_inclusive(start_page, end_page);
+        for page in page_range {
+            unsafe {
+                match page_table.update_flags(page, flags) {
+                    Ok(flush) => flush.flush(),
+                    Err(e) => {
+                        eprintln!(
+                            "SC> mprotect({:#?}, {}, {}, …) = EINVAL ({:#?})",
+                            addr, len, prot, e
+                        );
+                        return Err(libc::EINVAL);
+                    }
+                }
+            }
+        }
+        eprintln!("SC> mprotect({:#?}, {}, {}, …) = 0", addr, len, prot);
+
+        Ok(Default::default())
     }
 
-    if prot & libc::PROT_EXEC == 0 {
-        flags |= PageTableFlags::NO_EXECUTE;
+    fn mmap(
+        &mut self,
+        addr: UntrustedRef<u8>,
+        length: usize,
+        prot: i32,
+        flags: i32,
+        fd: i32,
+        offset: i64,
+    ) -> sallyport::Result {
+        self.trace("mmap", 6);
+
+        const PA: i32 = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS;
+
+        match (addr.as_ptr(), length, prot, flags, fd, offset) {
+            (ptr, _, _, PA, -1, 0) if ptr.is_null() => {
+                let mut flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+
+                if prot & libc::PROT_WRITE != 0 {
+                    flags |= PageTableFlags::WRITABLE;
+                }
+
+                if prot & libc::PROT_EXEC == 0 {
+                    flags |= PageTableFlags::NO_EXECUTE;
+                }
+
+                let virt_addr = *NEXT_MMAP_RWLOCK.read().deref();
+                let len_aligned = align_up(length as _, Page::<Size4KiB>::SIZE) as _;
+
+                let mem_slice = FRAME_ALLOCATOR
+                    .write()
+                    .allocate_and_map_memory(
+                        SHIM_PAGETABLE.write().deref_mut(),
+                        virt_addr,
+                        len_aligned,
+                        flags,
+                        PageTableFlags::PRESENT
+                            | PageTableFlags::WRITABLE
+                            | PageTableFlags::USER_ACCESSIBLE,
+                    )
+                    .map_err(|_| {
+                        eprintln!("SC> mmap(0, {}, …) = ENOMEM", length);
+                        libc::ENOMEM
+                    })?;
+                eprintln!("SC> mmap(0, {}, …) = {:#?}", length, mem_slice.as_ptr());
+                unsafe {
+                    core::ptr::write_bytes(mem_slice.as_mut_ptr(), 0, length);
+                }
+                *NEXT_MMAP_RWLOCK.write().deref_mut() = virt_addr + (len_aligned as u64);
+
+                //eprintln!("next_mmap = {:#x}", *NEXT_MMAP_RWLOCK::read().deref());
+
+                Ok([mem_slice.as_ptr().into(), Default::default()])
+            }
+            (addr, ..) => {
+                eprintln!("SC> mmap({:#?}, {}, …)", addr, length);
+                unimplemented!()
+            }
+        }
     }
 
-    let mut page_table = SHIM_PAGETABLE.write();
+    fn munmap(&mut self, _addr: UntrustedRef<u8>, _lenght: usize) -> sallyport::Result {
+        self.trace("munmap", 2);
+        Ok(Default::default())
+    }
 
-    let start_addr = VirtAddr::from_ptr(addr);
-    let start_page: Page = Page::containing_address(start_addr);
-    let end_page: Page = Page::containing_address(start_addr + len - 1u64);
-    let page_range = Page::range_inclusive(start_page, end_page);
-    for page in page_range {
-        unsafe {
-            match page_table.update_flags(page, flags) {
-                Ok(flush) => flush.flush(),
-                Err(e) => {
-                    eprintln!(
-                        "SC> mprotect({:#?}, {}, {}, …) = EINVAL ({:#?})",
-                        addr, len, prot, e
-                    );
+    fn brk(&mut self, addr: *const u8) -> sallyport::Result {
+        self.trace("brk", 1);
+        let len;
+
+        let next_brk = *NEXT_BRK_RWLOCK.read().deref();
+        let virt_addr = next_brk;
+
+        match addr as usize {
+            0 => {
+                eprintln!("SC> brk({:#?}) = {:#x}", addr, next_brk.as_u64());
+                Ok([next_brk.as_u64().into(), Default::default()])
+            }
+            n => {
+                if n <= next_brk.as_u64() as usize {
+                    if n > (next_brk
+                        .as_u64()
+                        .checked_sub(Page::<Size4KiB>::SIZE)
+                        .unwrap() as usize)
+                    {
+                        // already mapped
+                        eprintln!("SC> brk({:#?}) = {:#x}", addr, n);
+                        return Ok([n.into(), Default::default()]);
+                    }
+
+                    // n most likely wrong
                     return Err(libc::EINVAL);
                 }
+
+                len = n
+                    .checked_sub(next_brk.as_u64() as usize)
+                    .ok_or(libc::EINVAL)?;
+                let len_aligned = align_up(len as _, Page::<Size4KiB>::SIZE) as _;
+                let _ = FRAME_ALLOCATOR
+                    .write()
+                    .allocate_and_map_memory(
+                        SHIM_PAGETABLE.write().deref_mut(),
+                        virt_addr,
+                        len_aligned,
+                        PageTableFlags::PRESENT
+                            | PageTableFlags::USER_ACCESSIBLE
+                            | PageTableFlags::WRITABLE,
+                        PageTableFlags::PRESENT
+                            | PageTableFlags::WRITABLE
+                            | PageTableFlags::USER_ACCESSIBLE,
+                    )
+                    .map_err(|_| {
+                        eprintln!("SC> brk({:#?}) = ENOMEM", addr);
+                        libc::ENOMEM
+                    })?;
+
+                *NEXT_BRK_RWLOCK.write() = virt_addr + (len_aligned as u64);
+
+                eprintln!("SC> brk({:#?}) = {:#x}", addr, n);
+
+                Ok([n.into(), Default::default()])
             }
         }
     }
-    eprintln!("SC> mprotect({:#?}, {}, {}, …) = 0", addr, len, prot);
 
-    Ok(0)
-}
-
-/// syscall
-pub fn mmap(
-    addr: *const u8,
-    length: libc::size_t,
-    prot: libc::c_int,
-    flags: libc::c_int,
-    fd: libc::c_int,
-    offset: libc::off_t,
-) -> Result<usize, libc::c_int> {
-    const PA: i32 = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS;
-
-    match (addr as u64, length, prot, flags, fd, offset) {
-        (0, _, _, PA, -1, 0) => {
-            let mut flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
-
-            if prot & libc::PROT_WRITE != 0 {
-                flags |= PageTableFlags::WRITABLE;
-            }
-
-            if prot & libc::PROT_EXEC == 0 {
-                flags |= PageTableFlags::NO_EXECUTE;
-            }
-
-            let virt_addr = *NEXT_MMAP_RWLOCK.read().deref();
-            let len_aligned = align_up(length as _, Page::<Size4KiB>::SIZE) as _;
-
-            let mem_slice = FRAME_ALLOCATOR
-                .write()
-                .allocate_and_map_memory(
-                    SHIM_PAGETABLE.write().deref_mut(),
-                    virt_addr,
-                    len_aligned,
-                    flags,
-                    PageTableFlags::PRESENT
-                        | PageTableFlags::WRITABLE
-                        | PageTableFlags::USER_ACCESSIBLE,
-                )
-                .map_err(|_| {
-                    eprintln!("SC> mmap({:#?}, {}, …) = ENOMEM", addr, length);
-                    libc::ENOMEM
-                })?;
-            eprintln!(
-                "SC> mmap({:#?}, {}, …) = {:#?}",
-                addr,
-                length,
-                mem_slice.as_ptr()
-            );
-            unsafe {
-                core::ptr::write_bytes(mem_slice.as_mut_ptr(), 0, length);
-            }
-            *NEXT_MMAP_RWLOCK.write().deref_mut() = virt_addr + (len_aligned as u64);
-
-            //eprintln!("next_mmap = {:#x}", *NEXT_MMAP_RWLOCK::read().deref());
-
-            Ok(mem_slice.as_ptr() as usize)
-        }
-        _ => {
-            eprintln!("SC> mmap({:#?}, {}, …)", addr, length);
-            unimplemented!()
-        }
+    fn madvise(
+        &mut self,
+        _addr: *const libc::c_void,
+        _length: usize,
+        _advice: i32,
+    ) -> sallyport::Result {
+        self.trace("madvise", 3);
+        Ok(Default::default())
     }
-}
-
-/// syscall
-pub fn brk(addr: *const u8) -> Result<usize, libc::c_int> {
-    let len;
-
-    let next_brk = *NEXT_BRK_RWLOCK.read().deref();
-    let virt_addr = next_brk;
-
-    match addr as usize {
-        0 => {
-            eprintln!("SC> brk({:#?}) = {:#x}", addr, next_brk.as_u64());
-            Ok(next_brk.as_u64() as _)
-        }
-        n => {
-            if n <= next_brk.as_u64() as usize {
-                if n > (next_brk
-                    .as_u64()
-                    .checked_sub(Page::<Size4KiB>::SIZE)
-                    .unwrap() as usize)
-                {
-                    // already mapped
-                    eprintln!("SC> brk({:#?}) = {:#x}", addr, n);
-                    return Ok(n);
-                }
-
-                // n most likely wrong
-                return Err(libc::EINVAL);
-            }
-
-            len = n.checked_sub(next_brk.as_u64() as usize).unwrap();
-            let len_aligned = align_up(len as _, Page::<Size4KiB>::SIZE) as _;
-            let _ = FRAME_ALLOCATOR
-                .write()
-                .allocate_and_map_memory(
-                    SHIM_PAGETABLE.write().deref_mut(),
-                    virt_addr,
-                    len_aligned,
-                    PageTableFlags::PRESENT
-                        | PageTableFlags::USER_ACCESSIBLE
-                        | PageTableFlags::WRITABLE,
-                    PageTableFlags::PRESENT
-                        | PageTableFlags::WRITABLE
-                        | PageTableFlags::USER_ACCESSIBLE,
-                )
-                .map_err(|_| {
-                    eprintln!("SC> brk({:#?}) = ENOMEM", addr);
-                    libc::ENOMEM
-                })?;
-
-            *NEXT_BRK_RWLOCK.write() = virt_addr + (len_aligned as u64);
-
-            eprintln!("SC> brk({:#?}) = {:#x}", addr, n);
-
-            Ok(n)
-        }
-    }
-}
-
-/// Do a ioctl() syscall
-///
-pub fn ioctl(fd: libc::c_int, request: libc::c_ulong) -> Result<usize, libc::c_int> {
-    match (fd as _, request as _) {
-        (libc::STDIN_FILENO, libc::TIOCGWINSZ)
-        | (libc::STDOUT_FILENO, libc::TIOCGWINSZ)
-        | (libc::STDERR_FILENO, libc::TIOCGWINSZ) => {
-            // the keep has no tty
-            eprintln!("SC> ioctl({}, TIOCGWINSZ, … = -ENOTTY", fd);
-            Err(libc::ENOTTY)
-        }
-        (libc::STDIN_FILENO, _) | (libc::STDOUT_FILENO, _) | (libc::STDERR_FILENO, _) => {
-            eprintln!("SC> ioctl({}, {}), … = -EINVAL", fd, request);
-            Err(libc::EINVAL)
-        }
-        _ => {
-            eprintln!("SC> ioctl({}, {}), … = -EBADFD", fd, request);
-            Err(libc::EBADFD)
-        }
-    }
-}
-/// Do a set_tid_address() syscall
-///
-/// This is currently unimplemented and returns a dummy thread id.
-pub fn set_tid_address(_tidptr: *mut libc::c_int) -> Result<usize, libc::c_int> {
-    // FIXME
-    eprintln!("SC> set_tid_address(…) = 1");
-    Ok(1)
-}
-
-/// Do a rt_sigaction() syscall
-///
-/// This is currently unimplemented and returns success.
-pub fn rt_sigaction(
-    _signum: libc::c_int,
-    _act: *const libc::sigaction,
-    _oldact: *mut libc::sigaction,
-) -> Result<usize, libc::c_int> {
-    // FIXME
-    eprintln!("SC> rt_sigaction(…) = 0");
-    Ok(0)
-}
-
-/// Do a rt_sigprocmask() syscall
-///
-/// This is currently unimplemented and returns success.
-pub fn rt_sigprocmask(
-    _how: libc::c_int,
-    _set: *const libc::c_void,
-    _oldset: *mut libc::c_void,
-    _sigsetsize: libc::size_t,
-) -> Result<usize, libc::c_int> {
-    // FIXME
-    eprintln!("SC> rt_sigprocmask(…) = 0");
-    Ok(0)
-}
-
-/// Do a munmap() syscall
-///
-/// This is currently unimplemented and returns success.
-pub fn munmap(_addr: *const libc::c_void, _lenght: libc::size_t) -> Result<usize, libc::c_int> {
-    // FIXME
-    eprintln!("SC> munmap(…) = 0");
-    Ok(0)
-}
-
-/// Do a sigaltstack() syscall
-///
-/// This is currently unimplemented and returns success.
-pub fn sigaltstack(
-    _ss: *const libc::stack_t,
-    _old_ss: *mut libc::stack_t,
-) -> Result<usize, libc::c_int> {
-    // FIXME
-    eprintln!("SC> sigaltstack(…) = 0");
-    Ok(0)
-}
-
-/// Do a getrandom() syscall
-///
-/// # Safety
-/// The caller has to ensure `buf` points to valid memory
-pub unsafe fn getrandom(
-    buf: *mut u8,
-    buflen: libc::size_t,
-    flags: libc::c_uint,
-) -> Result<usize, libc::c_int> {
-    let flags = flags & !(libc::GRND_NONBLOCK | libc::GRND_RANDOM);
-
-    if flags != 0 {
-        return Err(libc::EINVAL);
-    }
-
-    let trusted = core::slice::from_raw_parts_mut(buf, buflen);
-
-    for (i, chunk) in trusted.chunks_mut(8).enumerate() {
-        let mut el = 0u64;
-        loop {
-            if core::arch::x86_64::_rdrand64_step(&mut el) == 1 {
-                chunk.copy_from_slice(&el.to_ne_bytes()[..chunk.len()]);
-                break;
-            } else {
-                if (flags & libc::GRND_NONBLOCK) != 0 {
-                    eprintln!("SC> getrandom(…) = -EAGAIN");
-                    return Err(libc::EAGAIN);
-                }
-                if (flags & libc::GRND_RANDOM) != 0 {
-                    eprintln!("SC> getrandom(…) = {}", i.checked_mul(8).unwrap());
-                    return Ok(i.checked_mul(8).unwrap());
-                }
-            }
-        }
-    }
-    eprintln!("SC> getrandom(…) = {}", trusted.len());
-
-    Ok(trusted.len())
-}
-
-/// syscall
-pub fn clock_gettime(
-    clockid: libc::clockid_t,
-    tp: *mut libc::timespec,
-) -> Result<usize, libc::c_int> {
-    // FIXME: check `trusted`, if in payload space
-    // https://github.com/enarx/enarx-keepldr/issues/78
-    let trusted = NonNull::new(tp).ok_or(libc::EFAULT)?;
-
-    let mut host_call = HOST_CALL.try_lock().ok_or(libc::EIO)?;
-
-    let block = host_call.as_mut_block();
-
-    let c = block.cursor();
-    let (_, buf) = c.alloc::<libc::timespec>(1).or(Err(libc::EMSGSIZE))?;
-
-    let host_virt = blk_to_host_virt(buf.as_ptr());
-
-    block.msg.req = request!(libc::SYS_clock_gettime => clockid, host_virt);
-    let result = unsafe { host_call.hostcall() }.map(|r| r[0].into())?;
-
-    let block = host_call.as_mut_block();
-    let c = block.cursor();
-    unsafe { c.copy_into(trusted) }.or(Err(libc::EMSGSIZE))?;
-
-    Ok(result)
-}
-
-/// syscall
-///
-/// # Safety
-/// The caller has to ensure `buf` points to valid memory.
-pub unsafe fn uname(buf: *mut libc::utsname) -> Result<usize, libc::c_int> {
-    // Faked, because we cannot promise any features provided by Linux in the future.
-    eprintln!(
-        r##"SC> uname({{sysname="Linux", nodename="enarx", release="5.4.8", version="1", machine="x86_64", domainname="(none)"}}) = 0"##
-    );
-
-    let mut uts = MaybeUninit::<libc::utsname>::zeroed().assume_init();
-    uts.sysname[..5].copy_from_slice(TrySigned::try_signed(b"Linux").unwrap());
-    uts.nodename[..5].copy_from_slice(TrySigned::try_signed(b"enarx").unwrap());
-    uts.release[..5].copy_from_slice(TrySigned::try_signed(b"5.4.8").unwrap());
-    uts.version[..6].copy_from_slice(TrySigned::try_signed(b"#1 SMP").unwrap());
-    uts.machine[..6].copy_from_slice(TrySigned::try_signed(b"x86_64").unwrap());
-    buf.write(uts);
-    Ok(0)
-}
-
-/// syscall
-pub fn readlink(
-    pathname: *const libc::c_char,
-    buf: *mut libc::c_char,
-    bufsize: libc::size_t,
-) -> Result<usize, libc::c_int> {
-    // Fake readlink("/proc/self/exe")
-    const PROC_SELF_EXE: &str = "/proc/self/exe";
-
-    let pathname = unsafe {
-        let mut len: isize = 0;
-        let ptr: *const u8 = pathname as _;
-        loop {
-            if ptr.offset(len).read() == 0 {
-                break;
-            }
-            len = len.checked_add(1).unwrap();
-            if len as usize >= PROC_SELF_EXE.len() {
-                break;
-            }
-        }
-        core::str::from_utf8_unchecked(core::slice::from_raw_parts(pathname as _, len as _))
-    };
-
-    if !pathname.eq(PROC_SELF_EXE) {
-        return Err(libc::ENOENT);
-    }
-
-    let outbuf = unsafe { core::slice::from_raw_parts_mut(buf as _, bufsize as _) };
-    outbuf[..6].copy_from_slice(b"/init\0");
-    eprintln!("SC> readlink({:#?}, \"/init\", {}) = 5", pathname, bufsize);
-    Ok(5)
-}
-
-/// syscall
-///
-/// # Safety
-/// The caller has to ensure `statbuf` points to valid memory
-pub unsafe fn fstat(fd: libc::c_int, statbuf: *mut libc::stat) -> Result<usize, libc::c_int> {
-    // Fake fstat(0|1|2, ...) done by glibc or rust
-    match fd {
-        libc::STDIN_FILENO | libc::STDOUT_FILENO | libc::STDERR_FILENO => {
-            #[allow(clippy::integer_arithmetic)]
-            const fn makedev(x: u64, y: u64) -> u64 {
-                (((x) & 0xffff_f000u64) << 32)
-                    | (((x) & 0x0000_0fffu64) << 8)
-                    | (((y) & 0xffff_ff00u64) << 12)
-                    | ((y) & 0x0000_00ffu64)
-            }
-
-            let mut p = MaybeUninit::<libc::stat>::zeroed().assume_init();
-
-            p.st_dev = makedev(
-                0,
-                match fd {
-                    0 => 0x19,
-                    _ => 0xc,
-                },
-            );
-            p.st_ino = 3;
-            p.st_mode = libc::S_IFIFO | 0o600;
-            p.st_nlink = 1;
-            p.st_uid = 1000;
-            p.st_gid = 5;
-            p.st_blksize = 4096;
-            p.st_blocks = 0;
-            p.st_rdev = makedev(0x88, 0);
-            p.st_size = 0;
-
-            p.st_atime = 1_579_507_218 /* 2020-01-21T11:45:08.467721685+0100 */;
-            p.st_atime_nsec = 0;
-            p.st_mtime = 1_579_507_218 /* 2020-01-21T11:45:07.467721685+0100 */;
-            p.st_mtime_nsec = 0;
-            p.st_ctime = 1_579_507_218 /* 2020-01-20T09:00:18.467721685+0100 */;
-            p.st_ctime_nsec = 0;
-
-            statbuf.write(p);
-
-            eprintln!("SC> fstat({}, {{st_dev=makedev(0, 0x19), st_ino=3, st_mode=S_IFIFO|0600,\
-                 st_nlink=1, st_uid=1000, st_gid=5, st_blksize=4096, st_blocks=0, st_size=0,\
-                  st_rdev=makedev(0x88, 0), st_atime=1579507218 /* 2020-01-21T11:45:08.467721685+0100 */,\
-                   st_atime_nsec=0, st_mtime=1579507218 /* 2020-01-21T11:45:08.467721685+0100 */,\
-                    st_mtime_nsec=0, st_ctime=1579507218 /* 2020-01-21T11:45:08.467721685+0100 */,\
-                     st_ctime_nsec=0}}) = 0", fd);
-            Ok(0)
-        }
-        _ => Err(libc::EBADF),
-    }
-}
-
-/// syscall
-pub fn fcntl(fd: libc::c_int, cmd: libc::c_int) -> Result<usize, libc::c_int> {
-    match (fd, cmd) {
-        (libc::STDIN_FILENO, libc::F_GETFL) => {
-            eprintln!("SC> fcntl({}, F_GETFD) = 0x402 (flags O_RDWR|O_APPEND)", fd);
-            Ok((libc::O_RDWR | libc::O_APPEND) as _)
-        }
-        (libc::STDOUT_FILENO, libc::F_GETFL) | (libc::STDERR_FILENO, libc::F_GETFL) => {
-            eprintln!("SC> fcntl({}, F_GETFD) = 0x1 (flags O_WRONLY)", fd);
-            Ok(libc::O_WRONLY as _)
-        }
-        (libc::STDIN_FILENO, _) | (libc::STDOUT_FILENO, _) | (libc::STDERR_FILENO, _) => {
-            eprintln!("SC> fcntl({}, {}) = -EINVAL", fd, cmd);
-            Err(libc::EINVAL)
-        }
-        (_, _) => {
-            eprintln!("SC> fcntl({}, {}) = -EBADFD", fd, cmd);
-            Err(libc::EBADFD)
-        }
-    }
-}
-
-/// syscall
-pub fn madvise(
-    addr: *const libc::c_void,
-    length: libc::size_t,
-    advice: libc::c_int,
-) -> Result<usize, libc::c_int> {
-    eprintln!("SC> madvise(0x{:?}, {}, {}) = 0", addr, length, advice);
-
-    Ok(0)
-}
-
-/// syscall
-///
-/// # Safety
-/// The caller has to ensure `fds` points to valid memory.
-pub unsafe fn poll(
-    fds: *mut libc::pollfd,
-    nfds: libc::nfds_t,
-    timeout: libc::c_int,
-) -> Result<usize, libc::c_int> {
-    eprintln!("SC> poll(…) =  …");
-
-    let mut host_call = HOST_CALL.try_lock().ok_or(libc::EIO)?;
-
-    let block = host_call.as_mut_block();
-
-    let c = block.cursor();
-
-    let (_, buf) = c
-        .copy_from_raw_parts(fds, nfds as _)
-        .or(Err(libc::EMSGSIZE))?;
-
-    let host_virt = blk_to_host_virt(buf);
-
-    block.msg.req = request!(libc::SYS_poll => host_virt, nfds, timeout);
-    let result = host_call.hostcall().map(|r| r[0].into())?;
-
-    let block = host_call.as_mut_block();
-    let c = block.cursor();
-
-    c.copy_into_raw_parts(nfds as _, fds, nfds as _)
-        .or(Err(libc::EMSGSIZE))?;
-
-    Ok(result)
-}
-
-/// syscall
-pub fn getuid() -> Result<usize, libc::c_int> {
-    eprintln!("SC> getuid() = {}", FAKE_UID);
-    Ok(FAKE_UID)
-}
-
-/// syscall
-pub fn getgid() -> Result<usize, libc::c_int> {
-    eprintln!("SC> getgid() = {}", FAKE_GID);
-    Ok(FAKE_GID)
-}
-
-/// syscall
-pub fn geteuid() -> Result<usize, libc::c_int> {
-    eprintln!("SC> geteuid() = {}", FAKE_UID);
-    Ok(FAKE_UID)
-}
-
-/// syscall
-pub fn getegid() -> Result<usize, libc::c_int> {
-    eprintln!("SC> getegid() = {}", FAKE_GID);
-    Ok(FAKE_GID)
-}
-
-/// Convert an unsigned slice to a signed slice
-pub trait TrySigned<T>: Sized {
-    /// The type returned in the event of a conversion error.
-    type Error;
-
-    /// Performs the conversion.
-    fn try_signed(value: &[T]) -> Result<Self, Self::Error>;
-}
-
-impl TrySigned<u8> for &[i8] {
-    type Error = core::num::TryFromIntError;
-
-    fn try_signed(value: &[u8]) -> Result<Self, Self::Error> {
-        for c in value {
-            i8::try_from(*c)?;
-        }
-
-        let len = value.len();
-        let ptr = value.as_ptr() as *const i8;
-
-        Ok(unsafe { core::slice::from_raw_parts(ptr, len) })
-    }
-}
-
-/// Convert a `Block` buffer address to the host virtual address
-///
-/// # Panics
-/// If the `Block` buffer address is not in the unencrypted address space this function panics.
-fn blk_to_host_virt<T>(buf: *const T) -> HostVirtAddr<T> {
-    let buf_address = Address::from(buf);
-    let phys_unencrypted = ShimPhysUnencryptedAddr::try_from(buf_address).unwrap();
-    HostVirtAddr::from(phys_unencrypted)
 }

--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "scroll"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb2332cb595d33f7edd5700f4cbf94892e680c7f0ae56adab58a35190b66cb1"
+checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
 
 [[package]]
 name = "sgx"
@@ -161,13 +161,15 @@ dependencies = [
  "sallyport",
  "sgx",
  "sgx-heap",
+ "syscall",
+ "untrusted",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -175,10 +177,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syscall"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "primordial",
+ "sallyport",
+ "untrusted",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "untrusted"
+version = "0.1.0"
+dependencies = [
+ "primordial",
+]
 
 [[package]]
 name = "xsave"

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -13,6 +13,8 @@ test = false
 sallyport = { path = "../sallyport", default-features = false }
 rcrt1 = { path = "../rcrt1" }
 sgx-heap = { path = "../sgx-heap" }
+syscall = { path = "../syscall"}
+untrusted = { path = "../untrusted"}
 compiler_builtins = { version = "0.1", default-features = false, features = [ "mem" ] }
 sgx = { git = "https://github.com/enarx/sgx", rev = "512e077" }
 goblin = { version = "0.2", default-features = false, features = [ "elf64" ] }

--- a/internal/shim-sgx/src/event.rs
+++ b/internal/shim-sgx/src/event.rs
@@ -5,16 +5,13 @@ use sgx::types::ssa::{Exception, StateSaveArea};
 
 use crate::handler::{Context, Handler};
 use crate::Layout;
+use syscall::SyscallHandler;
 
 // Opcode constants, details in Volume 2 of the Intel 64 and IA-32 Architectures Software
 // Developer's Manual
 const OP_SYSCALL: &[u8] = &[0x0f, 0x05];
 const OP_CPUID: &[u8] = &[0x0f, 0xa2];
 const SYS_ERESUME: usize = !0;
-
-// Enarx pseudo-syscall for attestation handling
-// See https://github.com/enarx/enarx-keepldr/issues/31
-const SYS_GETATT: i64 = 0xEA01;
 
 #[no_mangle]
 pub extern "C" fn event(
@@ -34,40 +31,15 @@ pub extern "C" fn event(
         Some(Exception::InvalidOpcode) => {
             match unsafe { h.aex.gpr.rip.into_slice(2usize) } {
                 OP_SYSCALL => {
-                    let ret = match h.aex.gpr.rax.into() {
-                        libc::SYS_read => h.read(),
-                        libc::SYS_readv => h.readv(),
-                        libc::SYS_write => h.write(),
-                        libc::SYS_writev => h.writev(),
-                        libc::SYS_exit => h.exit(None),
-                        libc::SYS_getuid => h.getuid(),
-                        libc::SYS_getgid => h.getgid(),
-                        libc::SYS_geteuid => h.geteuid(),
-                        libc::SYS_getegid => h.getegid(),
-                        libc::SYS_arch_prctl => h.arch_prctl(),
-                        libc::SYS_exit_group => h.exit_group(None),
-                        libc::SYS_set_tid_address => h.set_tid_address(),
-                        libc::SYS_brk => h.brk(),
-                        libc::SYS_uname => h.uname(),
-                        libc::SYS_mprotect => h.mprotect(),
-                        libc::SYS_mmap => h.mmap(),
-                        libc::SYS_munmap => h.munmap(),
-                        libc::SYS_rt_sigaction => h.rt_sigaction(),
-                        libc::SYS_rt_sigprocmask => h.rt_sigprocmask(),
-                        libc::SYS_sigaltstack => h.sigaltstack(),
-                        libc::SYS_getrandom => h.getrandom(),
-                        libc::SYS_clock_gettime => h.clock_gettime(),
-                        libc::SYS_madvise => h.madvise(),
-                        libc::SYS_close => h.close(),
-                        libc::SYS_poll => h.poll(),
-                        SYS_GETATT => h.get_att(),
-
-                        _ if !crate::handler::TRACE => Err(libc::ENOSYS),
-                        syscall => {
-                            debugln!(h, "unsupported syscall: 0x{:x}", syscall as u64);
-                            Err(libc::ENOSYS)
-                        }
-                    };
+                    let ret = h.syscall(
+                        h.aex.gpr.rdi.into(),
+                        h.aex.gpr.rsi.into(),
+                        h.aex.gpr.rdx.into(),
+                        h.aex.gpr.r10.into(),
+                        h.aex.gpr.r8.into(),
+                        h.aex.gpr.r9.into(),
+                        h.aex.gpr.rax.into(),
+                    );
 
                     aex.gpr.rip = (usize::from(aex.gpr.rip) + 2).into();
                     match ret {

--- a/internal/shim-sgx/src/handler.rs
+++ b/internal/shim-sgx/src/handler.rs
@@ -3,28 +3,14 @@
 use crate::hostlib::SYS_CPUID;
 use crate::Layout;
 
-use sallyport::{request, Block, Request};
+use core::fmt::Write;
+use sallyport::{request, Block, Cursor, Request};
 use sgx::types::ssa::StateSaveArea;
 use sgx_heap::Heap;
-
-use core::convert::TryInto;
-use core::fmt::Write;
-use core::ptr::NonNull;
-use core::slice::from_raw_parts;
+use syscall::{SyscallHandler, ARCH_GET_FS, ARCH_GET_GS, ARCH_SET_FS, ARCH_SET_GS, SGX_TECH};
+use untrusted::{AddressValidator, UntrustedRef, ValidateSlice};
 
 pub const TRACE: bool = false;
-
-const FAKE_UID: usize = 1000;
-const FAKE_GID: usize = 1000;
-
-// See https://github.com/enarx/enarx-keepldr/issues/31
-const SGX_TECH: usize = 2;
-
-// arch_prctl syscalls not available in the libc crate as of version 0.2.69
-const ARCH_SET_GS: usize = 0x1001;
-const ARCH_SET_FS: usize = 0x1002;
-const ARCH_GET_FS: usize = 0x1003;
-const ARCH_GET_GS: usize = 0x1004;
 
 extern "C" {
     fn syscall(aex: &mut StateSaveArea, ctx: &Context) -> u64;
@@ -45,7 +31,7 @@ impl<'a> Write for Handler<'a> {
             return Ok(());
         }
 
-        let c = self.block.cursor();
+        let c = self.new_cursor();
         let (_, untrusted) = c.copy_from_slice(s.as_bytes()).or(Err(core::fmt::Error))?;
 
         let req = request!(libc::SYS_write => libc::STDERR_FILENO, untrusted, untrusted.len());
@@ -74,53 +60,6 @@ impl<'a> Handler<'a> {
             block,
         }
     }
-
-    #[inline(never)]
-    unsafe fn proxy(&mut self, req: Request) -> sallyport::Result {
-        self.block.msg.req = req;
-
-        // prevent earlier writes from being moved beyond this point
-        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::Release);
-
-        let _ret = syscall(self.aex, self.ctx);
-
-        // prevent later reads from being moved before this point
-        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::Acquire);
-
-        self.block.msg.rep.into()
-    }
-
-    /// When we are under attack, we trip this circuit breaker and
-    /// exit the enclave. Any attempt to re-enter the enclave after
-    /// tripping the circuit breaker causes the enclave to immediately
-    /// EEXIT.
-    pub fn attacked(&mut self) -> ! {
-        self.exit(1)
-    }
-
-    fn trace(&mut self, name: &str, argc: usize) {
-        if !TRACE {
-            return;
-        }
-
-        let argv = [
-            self.aex.gpr.rdi,
-            self.aex.gpr.rsi,
-            self.aex.gpr.rdx,
-            self.aex.gpr.r10,
-            self.aex.gpr.r8,
-            self.aex.gpr.r9,
-        ];
-
-        debug!(self, "{}(", name);
-        for (i, arg) in argv[..argc].iter().copied().enumerate() {
-            let prefix = if i > 0 { ", " } else { "" };
-            debug!(self, "{}0x{:x}", prefix, u64::from(arg));
-        }
-
-        debugln!(self, ")");
-    }
-
     pub fn cpuid(&mut self) {
         if TRACE {
             debug!(
@@ -159,126 +98,106 @@ impl<'a> Handler<'a> {
             );
         }
     }
+}
+
+impl<'a> AddressValidator for Handler<'a> {
+    fn validate_const_mem_fn(&self, _ptr: *const (), _size: usize) -> bool {
+        // FIXME: https://github.com/enarx/enarx/issues/630
+        true
+    }
+
+    fn validate_mut_mem_fn(&self, _ptr: *mut (), _size: usize) -> bool {
+        // FIXME: https://github.com/enarx/enarx/issues/630
+        true
+    }
+}
+
+impl<'a> SyscallHandler for Handler<'a> {
+    fn translate_shim_to_host_addr<T>(&self, buf: *const T) -> *const T {
+        buf
+    }
+
+    fn new_cursor(&mut self) -> Cursor {
+        self.block.cursor()
+    }
+
+    unsafe fn proxy(&mut self, req: Request) -> sallyport::Result {
+        self.block.msg.req = req;
+
+        // prevent earlier writes from being moved beyond this point
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::Release);
+
+        let _ret = syscall(self.aex, self.ctx);
+
+        // prevent later reads from being moved before this point
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::Acquire);
+
+        self.block.msg.rep.into()
+    }
+
+    /// When we are under attack, we trip this circuit breaker and
+    /// exit the enclave. Any attempt to re-enter the enclave after
+    /// tripping the circuit breaker causes the enclave to immediately
+    /// EEXIT.
+    fn attacked(&mut self) -> ! {
+        self.exit(1)
+    }
+
+    fn trace(&mut self, name: &str, argc: usize) {
+        if !TRACE {
+            return;
+        }
+
+        let argv = [
+            self.aex.gpr.rdi,
+            self.aex.gpr.rsi,
+            self.aex.gpr.rdx,
+            self.aex.gpr.r10,
+            self.aex.gpr.r8,
+            self.aex.gpr.r9,
+        ];
+
+        debug!(self, "{}(", name);
+        for (i, arg) in argv[..argc].iter().copied().enumerate() {
+            let prefix = if i > 0 { ", " } else { "" };
+            debug!(self, "{}0x{:x}", prefix, u64::from(arg));
+        }
+
+        debugln!(self, ")");
+    }
 
     /// Proxy an exit() syscall
-    ///
-    /// The optional `code` parameter overrides the value from `aex`.
-    pub fn exit<T: Into<Option<u8>>>(&mut self, code: T) -> ! {
+    fn exit(&mut self, status: libc::c_int) -> ! {
         self.trace("exit", 1);
-
-        let code = code
-            .into()
-            .map(|x| x.into())
-            .unwrap_or_else(|| self.aex.gpr.rdi);
 
         #[allow(unused_must_use)]
         loop {
-            unsafe { self.proxy(request!(libc::SYS_exit => code)) };
+            unsafe { self.proxy(request!(libc::SYS_exit => status)) };
         }
     }
 
     /// Proxy an exitgroup() syscall
     ///
-    /// The optional `code` parameter overrides the value from `aex`.
     /// TODO: Currently we are only using one thread, so this will behave the
     /// same way as exit(). In the future, this implementation will change.
-    pub fn exit_group<T: Into<Option<u8>>>(&mut self, code: T) -> ! {
+    fn exit_group(&mut self, status: libc::c_int) -> ! {
         self.trace("exit_group", 1);
 
-        let code = code
-            .into()
-            .map(|x| x.into())
-            .unwrap_or_else(|| self.aex.gpr.rdi);
         #[allow(unused_must_use)]
         loop {
-            unsafe { self.proxy(request!(libc::SYS_exit_group => code)) };
+            unsafe { self.proxy(request!(libc::SYS_exit_group => status)) };
         }
-    }
-
-    /// Do a getuid() syscall
-    pub fn getuid(&mut self) -> sallyport::Result {
-        self.trace("getuid", 0);
-        Ok([FAKE_UID.into(), 0.into()])
-    }
-
-    /// Do a getgid() syscall
-    pub fn getgid(&mut self) -> sallyport::Result {
-        self.trace("getgid", 0);
-        Ok([FAKE_GID.into(), 0.into()])
-    }
-
-    /// Do a geteuid() syscall
-    pub fn geteuid(&mut self) -> sallyport::Result {
-        self.trace("geteuid", 0);
-        Ok([FAKE_UID.into(), 0.into()])
-    }
-
-    /// Do a getegid() syscall
-    pub fn getegid(&mut self) -> sallyport::Result {
-        self.trace("getegid", 0);
-        Ok([FAKE_GID.into(), 0.into()])
-    }
-
-    /// Do a read() syscall
-    pub fn read(&mut self) -> sallyport::Result {
-        self.trace("read", 3);
-
-        let c = self.block.cursor();
-        let trusted_len: usize = self.aex.gpr.rdx.into();
-        let trusted: *mut u8 = self.aex.gpr.rsi.into();
-        let (_, untrusted) = c.alloc::<u8>(trusted_len).or(Err(libc::EMSGSIZE))?;
-
-        let req = request!(libc::SYS_read => self.aex.gpr.rdi, untrusted, untrusted.len());
-        let ret = unsafe { self.proxy(req)? };
-
-        if trusted_len < ret[0].into() {
-            self.attacked();
-        }
-
-        let c = self.block.cursor();
-        unsafe { c.copy_into_raw_parts(trusted_len, trusted, ret[0].into()) }
-            .or(Err(libc::EMSGSIZE))?;
-
-        Ok(ret)
-    }
-
-    /// Do a write() syscall
-    pub fn write(&mut self) -> sallyport::Result {
-        self.trace("write", 3);
-
-        let c = self.block.cursor();
-        let trusted: *mut u8 = self.aex.gpr.rsi.into();
-        let trusted_len: usize = self.aex.gpr.rdx.into();
-        let (_, untrusted) =
-            unsafe { c.copy_from_raw_parts(trusted, trusted_len) }.or(Err(libc::EMSGSIZE))?;
-
-        let req = request!(libc::SYS_write => self.aex.gpr.rdi, untrusted, trusted_len);
-        let res = unsafe { self.proxy(req)? };
-
-        if trusted_len < res[0].into() {
-            self.attacked();
-        }
-
-        Ok(res)
-    }
-
-    /// Do a set_tid_address() syscall
-    // This is currently unimplemented and returns a dummy thread id.
-    pub fn set_tid_address(&mut self) -> sallyport::Result {
-        self.trace("set_tid_address", 1);
-
-        Ok([1.into(), 0.into()])
     }
 
     /// Do an arch_prctl() syscall
-    pub fn arch_prctl(&mut self) -> sallyport::Result {
+    fn arch_prctl(&mut self, code: libc::c_int, addr: libc::c_ulong) -> sallyport::Result {
         self.trace("arch_prctl", 2);
 
         // TODO: Check that addr in %rdx does not point to an unmapped address
         // and is not outside of the process address space.
-        match self.aex.gpr.rdi.into() {
-            ARCH_SET_FS => self.aex.gpr.fsbase = self.aex.gpr.rsi,
-            ARCH_SET_GS => self.aex.gpr.gsbase = self.aex.gpr.rsi,
+        match code {
+            ARCH_SET_FS => self.aex.gpr.fsbase = addr.into(),
+            ARCH_SET_GS => self.aex.gpr.gsbase = addr.into(),
             ARCH_GET_FS => return Err(libc::ENOSYS),
             ARCH_GET_GS => return Err(libc::ENOSYS),
             _ => return Err(libc::EINVAL),
@@ -288,26 +207,32 @@ impl<'a> Handler<'a> {
     }
 
     /// Do a readv() syscall
-    pub fn readv(&mut self) -> sallyport::Result {
+    fn readv(
+        &mut self,
+        fd: libc::c_int,
+        iovec: UntrustedRef<libc::iovec>,
+        iovcnt: libc::c_int,
+    ) -> sallyport::Result {
         self.trace("readv", 3);
 
         let mut size = 0usize;
-        let c = self.block.cursor();
-        let trusted = unsafe { self.aex.gpr.rsi.into_slice_mut(self.aex.gpr.rdx) };
+        let trusted = iovec.validate_slice(iovcnt, self).ok_or(libc::EFAULT)?;
+
+        let c = self.new_cursor();
 
         let (c, untrusted) = c
             .copy_from_slice::<libc::iovec>(trusted)
             .or(Err(libc::EMSGSIZE))?;
 
         let mut c = c;
-        for (t, u) in trusted.iter_mut().zip(untrusted.iter_mut()) {
+        for (t, u) in trusted.iter().zip(untrusted.iter_mut()) {
             let (nc, us) = c.alloc::<u8>(t.iov_len).or(Err(libc::EMSGSIZE))?;
             c = nc;
             u.iov_base = us.as_mut_ptr() as _;
             size += u.iov_len;
         }
 
-        let req = request!(libc::SYS_readv => self.aex.gpr.rdi, untrusted, untrusted.len());
+        let req = request!(libc::SYS_readv => fd, untrusted, untrusted.len());
         let ret = unsafe { self.proxy(req)? };
 
         let mut read = ret[0].into();
@@ -315,13 +240,13 @@ impl<'a> Handler<'a> {
             self.attacked();
         }
 
-        let c = self.block.cursor();
+        let c = self.new_cursor();
         let (c, _) = c
             .alloc::<libc::iovec>(trusted.len())
             .or(Err(libc::EMSGSIZE))?;
 
         let mut c = c;
-        for t in trusted.iter_mut() {
+        for t in trusted.iter() {
             let ts = t.iov_base as *mut u8;
             let ts_len: usize = t.iov_len;
 
@@ -337,26 +262,31 @@ impl<'a> Handler<'a> {
     }
 
     /// Do a writev() syscall
-    pub fn writev(&mut self) -> sallyport::Result {
+    fn writev(
+        &mut self,
+        fd: libc::c_int,
+        iovec: UntrustedRef<libc::iovec>,
+        iovcnt: libc::c_int,
+    ) -> sallyport::Result {
         self.trace("writev", 3);
 
         let mut size = 0usize;
-        let c = self.block.cursor();
-        let trusted = unsafe { self.aex.gpr.rsi.into_slice_mut(self.aex.gpr.rdx) };
+        let trusted = iovec.validate_slice(iovcnt, self).ok_or(libc::EFAULT)?;
+        let c = self.new_cursor();
         let (c, untrusted) = c
             .copy_from_slice::<libc::iovec>(trusted)
             .or(Err(libc::EMSGSIZE))?;
 
         let mut c = c;
-        for (t, mut u) in trusted.iter_mut().zip(untrusted.iter_mut()) {
-            let ts = unsafe { from_raw_parts(t.iov_base as *const u8, t.iov_len) };
-            let (nc, us) = c.copy_from_slice(ts).or(Err(libc::EMSGSIZE))?;
+        for (t, mut u) in trusted.iter().zip(untrusted.iter_mut()) {
+            let (nc, us) = unsafe { c.copy_from_raw_parts(t.iov_base as *const u8, t.iov_len) }
+                .or(Err(libc::EMSGSIZE))?;
             c = nc;
-            u.iov_base = us.as_mut_ptr() as _;
+            u.iov_base = us as _;
             size += u.iov_len;
         }
 
-        let req = request!(libc::SYS_writev => self.aex.gpr.rdi, untrusted, untrusted.len());
+        let req = request!(libc::SYS_writev => fd, untrusted, untrusted.len());
         let ret = unsafe { self.proxy(req)? };
 
         if size < ret[0].into() {
@@ -367,221 +297,78 @@ impl<'a> Handler<'a> {
     }
 
     /// Do a brk() system call
-    pub fn brk(&mut self) -> sallyport::Result {
+    fn brk(&mut self, addr: *const u8) -> sallyport::Result {
         self.trace("brk", 1);
 
         let mut heap = unsafe { Heap::new(self.layout.heap.into()) };
-        let ret = heap.brk(self.aex.gpr.rdi.into());
+        let ret = heap.brk(addr as _);
         Ok([ret.into(), Default::default()])
-    }
-
-    /// Do a uname() system call
-    pub fn uname(&mut self) -> sallyport::Result {
-        self.trace("uname", 1);
-
-        fn fill(buf: &mut [i8; 65], with: &str) {
-            let src = with.as_bytes();
-            for (i, b) in buf.iter_mut().enumerate() {
-                *b = *src.get(i).unwrap_or(&0) as i8;
-            }
-        }
-
-        let u: *mut libc::utsname = self.aex.gpr.rdi.into();
-        let u = unsafe { &mut *u };
-        fill(&mut u.sysname, "Linux");
-        fill(&mut u.nodename, "localhost.localdomain");
-        fill(&mut u.release, "5.6.0");
-        fill(&mut u.version, "#1");
-        fill(&mut u.machine, "x86_64");
-
-        Ok(Default::default())
     }
 
     /// Do a mprotect() system call
     // Until EDMM, we can't change any page permissions.
     // What you get is what you get. Fake success.
-    pub fn mprotect(&mut self) -> sallyport::Result {
+    fn mprotect(
+        &mut self,
+        _addr: UntrustedRef<u8>,
+        _len: libc::size_t,
+        _prot: libc::c_int,
+    ) -> sallyport::Result {
         self.trace("mprotect", 3);
 
         Ok(Default::default())
     }
 
     /// Do a mmap() system call
-    pub fn mmap(&mut self) -> sallyport::Result {
+    fn mmap(
+        &mut self,
+        addr: UntrustedRef<u8>,
+        length: libc::size_t,
+        prot: libc::c_int,
+        flags: libc::c_int,
+        fd: libc::c_int,
+        offset: libc::off_t,
+    ) -> sallyport::Result {
         self.trace("mmap", 6);
 
         let mut heap = unsafe { Heap::new(self.layout.heap.into()) };
         let ret = heap.mmap::<libc::c_void>(
-            self.aex.gpr.rdi.into(),
-            self.aex.gpr.rsi.into(),
-            self.aex.gpr.rdx.try_into().or(Err(libc::EINVAL))?,
-            self.aex.gpr.r10.try_into().or(Err(libc::EINVAL))?,
-            usize::from(self.aex.gpr.r8) as _, // Allow truncation!
-            self.aex.gpr.r9.into(),
+            addr.as_ptr() as _,
+            length,
+            prot,
+            flags,
+            fd, // Allow truncation!
+            offset,
         )?;
 
         Ok([ret.into(), Default::default()])
     }
 
     /// Do a munmap() system call
-    pub fn munmap(&mut self) -> sallyport::Result {
+    fn munmap(&mut self, addr: UntrustedRef<u8>, lenght: libc::size_t) -> sallyport::Result {
         self.trace("munmap", 2);
 
         let mut heap = unsafe { Heap::new(self.layout.heap.into()) };
-        heap.munmap::<libc::c_void>(self.aex.gpr.rdi.into(), self.aex.gpr.rsi.into())?;
+        heap.munmap::<libc::c_void>(addr.as_ptr() as _, lenght)?;
         Ok(Default::default())
-    }
-
-    /// Do a rt_sigaction() system call
-    // We don't support signals yet. So, fake success.
-    pub fn rt_sigaction(&mut self) -> sallyport::Result {
-        self.trace("rt_sigaction", 4);
-
-        type SigAction = [u64; 4];
-        const SIGRTMAX: usize = 64; // TODO: add to libc crate
-        static mut ACTIONS: [SigAction; SIGRTMAX] = [[0; 4]; SIGRTMAX];
-
-        let signal: usize = self.aex.gpr.rdi.into();
-        let new: *const SigAction = self.aex.gpr.rsi.into();
-        let old: *mut SigAction = self.aex.gpr.rdx.into();
-        let size: usize = self.aex.gpr.r10.into();
-
-        if signal >= SIGRTMAX || size != 8 {
-            return Err(libc::EINVAL);
-        }
-
-        unsafe {
-            let tmp = ACTIONS[signal];
-
-            if !new.is_null() {
-                ACTIONS[signal] = *new;
-            }
-
-            if !old.is_null() {
-                *old = tmp;
-            }
-        }
-
-        Ok(Default::default())
-    }
-
-    /// Do a rt_sigprocmask() system call
-    // We don't support signals yet. So, fake success.
-    pub fn rt_sigprocmask(&mut self) -> sallyport::Result {
-        self.trace("rt_sigprocmask", 4);
-
-        Ok(Default::default())
-    }
-
-    /// Do a sigaltstack() system call
-    // We don't support signals yet. So, fake success.
-    pub fn sigaltstack(&mut self) -> sallyport::Result {
-        self.trace("sigaltstack", 2);
-
-        Ok(Default::default())
-    }
-
-    /// Do a getrandom() syscall
-    pub fn getrandom(&mut self) -> sallyport::Result {
-        self.trace("getrandom", 3);
-
-        let flags: libc::c_uint = self.aex.gpr.rdx.try_into().or(Err(libc::EINVAL))?;
-        let flags = flags & !(libc::GRND_NONBLOCK | libc::GRND_RANDOM);
-
-        if flags != 0 {
-            return Err(libc::EINVAL);
-        }
-
-        let trusted: &mut [u8] = unsafe { self.aex.gpr.rdi.into_slice_mut(self.aex.gpr.rsi) };
-
-        for (i, chunk) in trusted.chunks_mut(8).enumerate() {
-            let mut el = 0u64;
-            loop {
-                if unsafe { core::arch::x86_64::_rdrand64_step(&mut el) } == 1 {
-                    chunk.copy_from_slice(&el.to_ne_bytes()[..chunk.len()]);
-                    break;
-                } else {
-                    if flags & libc::GRND_NONBLOCK != 0 {
-                        return Err(libc::EAGAIN);
-                    }
-                    if flags & libc::GRND_RANDOM != 0 {
-                        return Ok([(i * 8).into(), Default::default()]);
-                    }
-                }
-            }
-        }
-
-        Ok([trusted.len().into(), Default::default()])
-    }
-
-    // Do clock_gettime syscall
-    pub fn clock_gettime(&mut self) -> sallyport::Result {
-        self.trace("clock_gettime", 2);
-
-        let clk_id = self.aex.gpr.rdi;
-        let trusted = self.aex.gpr.rsi.into();
-        // FIXME: check `trusted`, if in payload space
-        // https://github.com/enarx/enarx-keepldr/issues/78
-        let trusted = NonNull::<libc::timespec>::new(trusted).ok_or(libc::EFAULT)?;
-
-        let c = self.block.cursor();
-        let (_, untrusted) = c.alloc::<libc::timespec>(1).or(Err(libc::EMSGSIZE))?;
-        let req = request!(libc::SYS_clock_gettime => clk_id, untrusted);
-        let res = unsafe { self.proxy(req)? };
-
-        if 0usize != res[0].into() {
-            self.attacked();
-        }
-
-        let c = self.block.cursor();
-        unsafe {
-            c.copy_into::<libc::timespec>(trusted)
-                .or(Err(libc::EMSGSIZE))?;
-        }
-
-        Ok(res)
     }
 
     // Do madvise syscall
     // We don't actually support this. So, fake success.
-    pub fn madvise(&mut self) -> sallyport::Result {
+    fn madvise(
+        &mut self,
+        _addr: *const libc::c_void,
+        _length: libc::size_t,
+        _advice: libc::c_int,
+    ) -> sallyport::Result {
         self.trace("madvise", 3);
         Ok(Default::default())
     }
 
-    // Do close syscall
-    pub fn close(&mut self) -> sallyport::Result {
-        self.trace("close", 1);
-        unsafe { self.proxy(request!(libc::SYS_close => self.aex.gpr.rdi)) }
-    }
-
-    // Do poll syscall
-    pub fn poll(&mut self) -> sallyport::Result {
-        self.trace("poll", 3);
-        let nfds: libc::nfds_t = self.aex.gpr.rsi.try_into().or(Err(libc::EINVAL))?;
-        let timeout: libc::c_int = self.aex.gpr.rdx.try_into().or(Err(libc::EINVAL))?;
-        let trusted: *mut libc::pollfd = self.aex.gpr.rdi.into();
-
-        let c = self.block.cursor();
-
-        let (_, untrusted) =
-            unsafe { c.copy_from_raw_parts(trusted, nfds as _) }.or(Err(libc::EMSGSIZE))?;
-
-        let req = request!(libc::SYS_poll => untrusted, nfds, timeout);
-        let result = unsafe { self.proxy(req)? };
-
-        let c = self.block.cursor();
-
-        unsafe { c.copy_into_raw_parts(nfds as _, trusted, nfds as _) }.or(Err(libc::EMSGSIZE))?;
-
-        Ok(result)
-    }
-
     // Stub for get_attestation() pseudo syscall
     // See: https://github.com/enarx/enarx-keepldr/issues/31
-    pub fn get_att(&mut self) -> sallyport::Result {
+    fn get_attestation(&mut self) -> sallyport::Result {
         self.trace("get_att", 0);
-        let rep: sallyport::Reply = Ok([0.into(), SGX_TECH.into()]).into();
-        sallyport::Result::from(rep)
+        Ok([0.into(), SGX_TECH.into()])
     }
 }

--- a/internal/syscall/Cargo.toml
+++ b/internal/syscall/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "syscall"
+version = "0.1.0"
+authors = ["Harald Hoyer <harald@redhat.com>"]
+license = "Apache-2.0"
+edition = "2018"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sallyport = { path = "../sallyport", default-features = false }
+untrusted = { path = "../untrusted"}
+libc = { version = "0.2", features = [] }
+primordial = "0.1"

--- a/internal/syscall/LICENSE
+++ b/internal/syscall/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/internal/syscall/src/lib.rs
+++ b/internal/syscall/src/lib.rs
@@ -1,0 +1,610 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Common syscall handling across shims
+
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![cfg_attr(not(test), no_std)]
+
+use core::convert::TryInto;
+use core::mem::MaybeUninit;
+use primordial::Register;
+use sallyport::{request, Cursor, Request, Result};
+use untrusted::{AddressValidator, UntrustedRef, UntrustedRefMut, Validate, ValidateSlice};
+
+/// `get_attestation` syscall number
+///
+/// See https://github.com/enarx/enarx-keepldr/issues/31
+pub const SYS_GETATT: i64 = 0xEA01;
+
+/// `get_attestation` technology return value
+///
+/// See https://github.com/enarx/enarx-keepldr/issues/31
+pub const SEV_TECH: usize = 1;
+
+/// `get_attestation` technology return value
+///
+/// See https://github.com/enarx/enarx-keepldr/issues/31
+pub const SGX_TECH: usize = 2;
+
+// arch_prctl syscalls not available in the libc crate as of version 0.2.69
+/// missing in libc
+pub const ARCH_SET_GS: libc::c_int = 0x1001;
+/// missing in libc
+pub const ARCH_SET_FS: libc::c_int = 0x1002;
+/// missing in libc
+pub const ARCH_GET_FS: libc::c_int = 0x1003;
+/// missing in libc
+pub const ARCH_GET_GS: libc::c_int = 0x1004;
+
+/// Fake uid returned by enarx
+pub const FAKE_UID: usize = 1000;
+/// Fake gid returned by enarx
+pub const FAKE_GID: usize = 1000;
+
+/// not defined in libc
+///
+/// FIXME
+pub struct KernelSigSet;
+
+type KernelSigAction = [u64; 4];
+
+/// A trait defining a shim syscall handler
+///
+/// Implemented for each shim. Some common methods are already implemented,
+/// but can be overwritten with optimized versions.
+pub trait SyscallHandler: AddressValidator + Sized {
+    /// Proxy a syscall `Request`
+    ///
+    /// # Safety
+    /// The caller has to ensure valid parameters.
+    unsafe fn proxy(&mut self, req: Request) -> Result;
+
+    /// Called, when the host might want to attack us, giving
+    /// the shim bogus values
+    fn attacked(&mut self) -> !;
+
+    /// Translates a shim virtual address to the host virtual address
+    fn translate_shim_to_host_addr<T>(&self, buf: *const T) -> *const T;
+
+    /// Returns a new `Cursor` for the sallyport `Block`
+    fn new_cursor(&mut self) -> Cursor;
+
+    /// Output tracing information about the syscall
+    fn trace(&mut self, name: &str, argc: usize);
+
+    /// Enarx syscall - get attestation
+    fn get_attestation(&mut self) -> Result;
+
+    /// syscall
+    fn exit(&mut self, status: libc::c_int) -> !;
+
+    /// syscall
+    fn exit_group(&mut self, status: libc::c_int) -> !;
+
+    /// syscall
+    fn arch_prctl(&mut self, code: libc::c_int, addr: libc::c_ulong) -> Result;
+
+    /// syscall
+    fn mprotect(&mut self, addr: UntrustedRef<u8>, len: libc::size_t, prot: libc::c_int) -> Result;
+
+    /// syscall
+    fn mmap(
+        &mut self,
+        addr: UntrustedRef<u8>,
+        length: libc::size_t,
+        prot: libc::c_int,
+        flags: libc::c_int,
+        fd: libc::c_int,
+        offset: libc::off_t,
+    ) -> Result;
+
+    /// Do a munmap() syscall
+    ///
+    /// This is currently unimplemented and returns success.
+    fn munmap(&mut self, addr: UntrustedRef<u8>, lenght: libc::size_t) -> Result;
+
+    /// syscall
+    fn brk(&mut self, addr: *const u8) -> Result;
+
+    /// syscall
+    fn madvise(
+        &mut self,
+        addr: *const libc::c_void,
+        length: libc::size_t,
+        advice: libc::c_int,
+    ) -> Result;
+
+    /// syscall
+    #[allow(clippy::too_many_arguments)]
+    fn syscall(
+        &mut self,
+        a: Register<usize>,
+        b: Register<usize>,
+        c: Register<usize>,
+        d: Register<usize>,
+        e: Register<usize>,
+        f: Register<usize>,
+        nr: usize,
+    ) -> Result {
+        let mut ret = match nr as _ {
+            libc::SYS_exit => self.exit(usize::from(a) as _),
+            libc::SYS_exit_group => self.exit_group(usize::from(a) as _),
+            libc::SYS_read => self.read(usize::from(a) as _, b.into(), c.into()),
+            libc::SYS_readv => self.readv(usize::from(a) as _, b.into(), usize::from(c) as _),
+            libc::SYS_write => self.write(usize::from(a) as _, b.into(), c.into()),
+            libc::SYS_writev => self.writev(usize::from(a) as _, b.into(), usize::from(c) as _),
+            libc::SYS_mmap => self.mmap(
+                a.into(),
+                b.into(),
+                c.try_into().map_err(|_| libc::EINVAL)?,
+                usize::from(d) as _,
+                usize::from(e) as _,
+                f.into(),
+            ),
+            libc::SYS_munmap => self.munmap(a.into(), b.into()),
+            libc::SYS_arch_prctl => self.arch_prctl(usize::from(a) as _, b.into()),
+            libc::SYS_set_tid_address => self.set_tid_address(a.into()),
+            libc::SYS_rt_sigaction => {
+                self.rt_sigaction(usize::from(a) as _, b.into(), c.into(), d.into())
+            }
+            libc::SYS_rt_sigprocmask => {
+                self.rt_sigprocmask(usize::from(a) as _, b.into(), c.into(), d.into())
+            }
+            libc::SYS_sigaltstack => self.sigaltstack(a.into(), b.into()),
+            libc::SYS_getrandom => self.getrandom(a.into(), b.into(), usize::from(c) as _),
+            libc::SYS_brk => self.brk(a.into()),
+            libc::SYS_ioctl => self.ioctl(usize::from(a) as _, b.into()),
+            libc::SYS_mprotect => self.mprotect(a.into(), b.into(), usize::from(c) as _),
+            libc::SYS_clock_gettime => self.clock_gettime(usize::from(a) as _, b.into()),
+            libc::SYS_uname => self.uname(a.into()),
+            libc::SYS_readlink => self.readlink(a.into(), b.into(), c.into()),
+            libc::SYS_fstat => self.fstat(usize::from(a) as _, b.into()),
+            libc::SYS_fcntl => self.fcntl(usize::from(a) as _, usize::from(b) as _),
+            libc::SYS_madvise => self.madvise(a.into(), b.into(), usize::from(c) as _),
+            libc::SYS_poll => self.poll(a.into(), b.into(), usize::from(c) as _),
+            libc::SYS_getuid => self.getuid(),
+            libc::SYS_getgid => self.getgid(),
+            libc::SYS_geteuid => self.geteuid(),
+            libc::SYS_getegid => self.getegid(),
+
+            SYS_GETATT => self.get_attestation(),
+
+            _ => Err(libc::ENOSYS),
+        };
+
+        #[cfg(target_arch = "x86_64")]
+        if nr < 0xEA00 {
+            // Non Enarx syscalls don't use `ret[1]` and have
+            // to return the original value of `rdx`.
+            ret = ret.map(|ret| [ret[0], c]);
+        }
+
+        ret
+    }
+
+    /// syscall
+    fn read(&mut self, fd: libc::c_int, buf: UntrustedRefMut<u8>, count: libc::size_t) -> Result {
+        self.trace("read", 4);
+
+        let buf = buf.validate_slice(count, self).ok_or(libc::EFAULT)?;
+
+        let c = self.new_cursor();
+
+        let (_, hostbuf) = c.alloc::<u8>(count).or(Err(libc::EMSGSIZE))?;
+        let hostbuf = hostbuf.as_ptr();
+        let host_virt = self.translate_shim_to_host_addr(hostbuf);
+
+        let ret = unsafe { self.proxy(request!(libc::SYS_read => fd, host_virt, count))? };
+
+        let result_len: usize = ret[0].into();
+
+        if count < result_len {
+            self.attacked();
+        }
+
+        let c = self.new_cursor();
+        c.copy_into_slice(count, buf.as_mut(), result_len)
+            .or(Err(libc::EFAULT))?;
+
+        Ok(ret)
+    }
+
+    /// syscall
+    fn readv(
+        &mut self,
+        fd: libc::c_int,
+        iovec: UntrustedRef<libc::iovec>,
+        iovcnt: libc::c_int,
+    ) -> Result {
+        self.trace("readv", 3);
+        // FIXME: this is not an ideal implementation of readv, but for the sake
+        // of simplicity this readv implementation behaves very much like how the
+        // Linux kernel would for a module that does not support readv, but does
+        // support read.
+        let mut bytes_read = 0usize;
+        for vec in iovec.validate_slice(iovcnt, self).ok_or(libc::EFAULT)? {
+            let r = self.read(fd, (vec.iov_base as *mut u8).into(), vec.iov_len as _)?;
+            bytes_read = bytes_read.checked_add(r[0].into()).unwrap();
+        }
+
+        Ok([bytes_read.into(), 0.into()])
+    }
+
+    /// syscall
+    fn write(&mut self, fd: libc::c_int, buf: UntrustedRef<u8>, count: libc::size_t) -> Result {
+        let buf = buf.validate_slice(count, self).ok_or(libc::EFAULT)?;
+
+        let c = self.new_cursor();
+        let (_, buf) = c.copy_from_slice(buf.as_ref()).or(Err(libc::EMSGSIZE))?;
+        let buf = buf.as_ptr();
+        let host_virt = self.translate_shim_to_host_addr(buf);
+
+        let ret = unsafe { self.proxy(request!(libc::SYS_write => fd, host_virt, count))? };
+        Ok(ret)
+    }
+
+    /// syscall
+    fn writev(
+        &mut self,
+        fd: libc::c_int,
+        iovec: UntrustedRef<libc::iovec>,
+        iovcnt: libc::c_int,
+    ) -> Result {
+        let iovec = iovec.validate_slice(iovcnt, self).ok_or(libc::EFAULT)?;
+
+        let mut size = 0usize;
+
+        for vec in iovec {
+            size +=
+                usize::from(self.write(fd, (vec.iov_base as *const u8).into(), vec.iov_len)?[0]);
+        }
+
+        Ok([size.into(), 0.into()])
+    }
+
+    /// syscall
+    fn ioctl(&mut self, fd: libc::c_int, request: libc::c_ulong) -> Result {
+        match (fd as _, request as _) {
+            (libc::STDIN_FILENO, libc::TIOCGWINSZ)
+            | (libc::STDOUT_FILENO, libc::TIOCGWINSZ)
+            | (libc::STDERR_FILENO, libc::TIOCGWINSZ) => {
+                // the keep has no tty
+                //eprintln!("SC> ioctl({}, TIOCGWINSZ, … = -ENOTTY", fd);
+                Err(libc::ENOTTY)
+            }
+            (libc::STDIN_FILENO, _) | (libc::STDOUT_FILENO, _) | (libc::STDERR_FILENO, _) => {
+                //eprintln!("SC> ioctl({}, {}), … = -EINVAL", fd, request);
+                Err(libc::EINVAL)
+            }
+            _ => {
+                //eprintln!("SC> ioctl({}, {}), … = -EBADFD", fd, request);
+                Err(libc::EBADFD)
+            }
+        }
+    }
+    /// Do a set_tid_address() syscall
+    ///
+    /// This is currently unimplemented and returns a dummy thread id.
+    fn set_tid_address(&mut self, _tidptr: *const libc::c_int) -> Result {
+        // FIXME
+        //eprintln!("SC> set_tid_address(…) = 1");
+        Ok([1.into(), 0.into()])
+    }
+
+    /// Do a rt_sigaction() system call
+    ///
+    /// We don't support signals yet. So, fake success.
+    fn rt_sigaction(
+        &mut self,
+        signum: libc::c_int,
+        act: UntrustedRef<KernelSigAction>,
+        oldact: UntrustedRefMut<KernelSigAction>,
+        size: usize,
+    ) -> Result {
+        self.trace("rt_sigaction", 4);
+
+        const SIGRTMAX: libc::c_int = 64; // TODO: add to libc crate
+        static mut ACTIONS: [KernelSigAction; SIGRTMAX as usize] = [[0; 4]; SIGRTMAX as usize];
+
+        if signum >= SIGRTMAX || size != 8 {
+            return Err(libc::EINVAL);
+        }
+
+        unsafe {
+            if !oldact.as_ptr().is_null() {
+                let oldact = oldact.validate(self).ok_or(libc::EFAULT)?;
+                *(oldact) = ACTIONS[signum as usize];
+            }
+
+            if !act.as_ptr().is_null() {
+                let act = act.validate(self).ok_or(libc::EFAULT)?;
+                ACTIONS[signum as usize] = *act;
+            }
+        }
+
+        Ok(Default::default())
+    }
+    /// Do a rt_sigprocmask() syscall
+    ///
+    /// We don't support signals yet. So, fake success.
+    fn rt_sigprocmask(
+        &mut self,
+        _how: libc::c_int,
+        _set: UntrustedRef<KernelSigSet>,
+        _oldset: UntrustedRefMut<KernelSigSet>,
+        _sigsetsize: libc::size_t,
+    ) -> Result {
+        // FIXME
+        self.trace("rt_sigprocmask", 4);
+        Ok(Default::default())
+    }
+
+    /// Do a sigaltstack() syscall
+    ///
+    /// This is currently unimplemented and returns success.
+    fn sigaltstack(
+        &mut self,
+        _ss: UntrustedRef<libc::stack_t>,
+        _old_ss: UntrustedRefMut<libc::stack_t>,
+    ) -> Result {
+        self.trace("sigaltstack", 2);
+
+        Ok(Default::default())
+    }
+
+    /// Do a getrandom() syscall
+    fn getrandom(
+        &mut self,
+        buf: UntrustedRefMut<u8>,
+        buflen: libc::size_t,
+        flags: libc::c_uint,
+    ) -> Result {
+        let flags = flags & !(libc::GRND_NONBLOCK | libc::GRND_RANDOM);
+
+        if flags != 0 {
+            return Err(libc::EINVAL);
+        }
+
+        let trusted = buf.validate_slice(buflen, self).ok_or(libc::EFAULT)?;
+
+        for (i, chunk) in trusted.chunks_mut(8).enumerate() {
+            let mut el = 0u64;
+            loop {
+                if unsafe { core::arch::x86_64::_rdrand64_step(&mut el) } == 1 {
+                    chunk.copy_from_slice(&el.to_ne_bytes()[..chunk.len()]);
+                    break;
+                } else {
+                    if (flags & libc::GRND_NONBLOCK) != 0 {
+                        //eprintln!("SC> getrandom(…) = -EAGAIN");
+                        return Err(libc::EAGAIN);
+                    }
+                    if (flags & libc::GRND_RANDOM) != 0 {
+                        //eprintln!("SC> getrandom(…) = {}", i.checked_mul(8).unwrap());
+                        return Ok([i.checked_mul(8).unwrap().into(), 0.into()]);
+                    }
+                }
+            }
+        }
+        //eprintln!("SC> getrandom(…) = {}", trusted.len());
+
+        Ok([trusted.len().into(), 0.into()])
+    }
+
+    /// syscall
+    fn clock_gettime(
+        &mut self,
+        clockid: libc::clockid_t,
+        tp: UntrustedRefMut<libc::timespec>,
+    ) -> Result {
+        self.trace("clock_gettime", 2);
+        let c = self.new_cursor();
+
+        let (_, buf) = c.alloc::<libc::timespec>(1).or(Err(libc::EMSGSIZE))?;
+        let buf = buf.as_ptr();
+        let host_virt = self.translate_shim_to_host_addr(buf);
+
+        let result =
+            unsafe { self.proxy(request!(libc::SYS_clock_gettime => clockid, host_virt))? };
+
+        let c = self.new_cursor();
+        *(tp.validate(self).ok_or(libc::EFAULT)?) = unsafe { c.read().or(Err(libc::EMSGSIZE))?.1 };
+
+        Ok(result)
+    }
+
+    /// Do a uname() system call
+    fn uname(&mut self, buf: UntrustedRefMut<libc::utsname>) -> Result {
+        self.trace("uname", 1);
+
+        fn fill(buf: &mut [i8; 65], with: &str) {
+            let src = with.as_bytes();
+            for (i, b) in buf.iter_mut().enumerate() {
+                *b = *src.get(i).unwrap_or(&0) as i8;
+            }
+        }
+
+        let u = buf.validate(self).ok_or(libc::EFAULT)?;
+        fill(&mut u.sysname, "Linux");
+        fill(&mut u.nodename, "localhost.localdomain");
+        fill(&mut u.release, "5.6.0");
+        fill(&mut u.version, "#1");
+        fill(&mut u.machine, "x86_64");
+
+        Ok(Default::default())
+    }
+
+    /// syscall
+    fn readlink(
+        &mut self,
+        pathname: UntrustedRef<u8>,
+        buf: UntrustedRefMut<u8>,
+        bufsize: libc::size_t,
+    ) -> Result {
+        // Fake readlink("/proc/self/exe")
+        const PROC_SELF_EXE: &str = "/proc/self/exe";
+
+        let pathname = unsafe {
+            let mut len: isize = 0;
+            let ptr: *const u8 = pathname.validate(self).ok_or(libc::EFAULT)? as _;
+            loop {
+                if ptr.offset(len).read() == 0 {
+                    break;
+                }
+                len = len.checked_add(1).unwrap();
+                if len as usize >= PROC_SELF_EXE.len() {
+                    break;
+                }
+            }
+            core::str::from_utf8_unchecked(core::slice::from_raw_parts(ptr, len as _))
+        };
+
+        if !pathname.eq(PROC_SELF_EXE) {
+            return Err(libc::ENOENT);
+        }
+
+        if bufsize < 6 {
+            return Err(libc::EINVAL);
+        }
+
+        let buf = buf.validate_slice(bufsize, self).ok_or(libc::EFAULT)?;
+        buf[..6].copy_from_slice(b"/init\0");
+        //eprintln!("SC> readlink({:#?}, \"/init\", {}) = 5", pathname, bufsize);
+        Ok([5.into(), 0.into()])
+    }
+
+    /// syscall
+    fn fstat(&mut self, fd: libc::c_int, statbuf: UntrustedRefMut<libc::stat>) -> Result {
+        // Fake fstat(0|1|2, ...) done by glibc or rust
+        match fd {
+            libc::STDIN_FILENO | libc::STDOUT_FILENO | libc::STDERR_FILENO => {
+                #[allow(clippy::integer_arithmetic)]
+                const fn makedev(x: u64, y: u64) -> u64 {
+                    (((x) & 0xffff_f000u64) << 32)
+                        | (((x) & 0x0000_0fffu64) << 8)
+                        | (((y) & 0xffff_ff00u64) << 12)
+                        | ((y) & 0x0000_00ffu64)
+                }
+
+                let mut p = unsafe { MaybeUninit::<libc::stat>::zeroed().assume_init() };
+
+                p.st_dev = makedev(
+                    0,
+                    match fd {
+                        0 => 0x19,
+                        _ => 0xc,
+                    },
+                );
+                p.st_ino = 3;
+                p.st_mode = libc::S_IFIFO | 0o600;
+                p.st_nlink = 1;
+                p.st_uid = 1000;
+                p.st_gid = 5;
+                p.st_blksize = 4096;
+                p.st_blocks = 0;
+                p.st_rdev = makedev(0x88, 0);
+                p.st_size = 0;
+
+                p.st_atime = 1_579_507_218 /* 2020-01-21T11:45:08.467721685+0100 */;
+                p.st_atime_nsec = 0;
+                p.st_mtime = 1_579_507_218 /* 2020-01-21T11:45:07.467721685+0100 */;
+                p.st_mtime_nsec = 0;
+                p.st_ctime = 1_579_507_218 /* 2020-01-20T09:00:18.467721685+0100 */;
+                p.st_ctime_nsec = 0;
+
+                let statbuf = statbuf.validate(self).ok_or(libc::EFAULT)?;
+                *statbuf = p;
+
+                /* eprintln!("SC> fstat({}, {{st_dev=makedev(0, 0x19), st_ino=3, st_mode=S_IFIFO|0600,\
+                st_nlink=1, st_uid=1000, st_gid=5, st_blksize=4096, st_blocks=0, st_size=0,\
+                 st_rdev=makedev(0x88, 0), st_atime=1579507218 /* 2020-01-21T11:45:08.467721685+0100 */,\
+                  st_atime_nsec=0, st_mtime=1579507218 /* 2020-01-21T11:45:08.467721685+0100 */,\
+                   st_mtime_nsec=0, st_ctime=1579507218 /* 2020-01-21T11:45:08.467721685+0100 */,\
+                    st_ctime_nsec=0}}) = 0", fd);
+
+                */
+                Ok(Default::default())
+            }
+            _ => Err(libc::EBADF),
+        }
+    }
+
+    /// syscall
+    fn fcntl(&self, fd: libc::c_int, cmd: libc::c_int) -> Result {
+        match (fd, cmd) {
+            (libc::STDIN_FILENO, libc::F_GETFL) => {
+                //eprintln!("SC> fcntl({}, F_GETFD) = 0x402 (flags O_RDWR|O_APPEND)", fd);
+                Ok([(libc::O_RDWR | libc::O_APPEND).into(), 0.into()])
+            }
+            (libc::STDOUT_FILENO, libc::F_GETFL) | (libc::STDERR_FILENO, libc::F_GETFL) => {
+                //eprintln!("SC> fcntl({}, F_GETFD) = 0x1 (flags O_WRONLY)", fd);
+                Ok([libc::O_WRONLY.into(), 0.into()])
+            }
+            (libc::STDIN_FILENO, _) | (libc::STDOUT_FILENO, _) | (libc::STDERR_FILENO, _) => {
+                //eprintln!("SC> fcntl({}, {}) = -EINVAL", fd, cmd);
+                Err(libc::EINVAL)
+            }
+            (_, _) => {
+                //eprintln!("SC> fcntl({}, {}) = -EBADFD", fd, cmd);
+                Err(libc::EBADFD)
+            }
+        }
+    }
+
+    /// syscall
+    fn poll(
+        &mut self,
+        fds: UntrustedRefMut<libc::pollfd>,
+        nfds: libc::nfds_t,
+        timeout: libc::c_int,
+    ) -> Result {
+        self.trace("poll", 3);
+
+        let fds = fds.validate_slice(nfds, self).ok_or(libc::EFAULT)?;
+
+        let c = self.new_cursor();
+
+        let (_, buf) = c.copy_from_slice(fds).or(Err(libc::EMSGSIZE))?;
+        let buf = buf.as_ptr();
+        let host_virt = self.translate_shim_to_host_addr(buf);
+
+        let result = unsafe { self.proxy(request!(libc::SYS_poll => host_virt, nfds, timeout))? };
+
+        let c = self.new_cursor();
+
+        c.copy_into_slice(nfds as _, fds, nfds as _)
+            .or(Err(libc::EMSGSIZE))?;
+
+        Ok(result)
+    }
+
+    /// Do a getuid() syscall
+    fn getuid(&mut self) -> Result {
+        self.trace("getuid", 0);
+        Ok([FAKE_UID.into(), 0.into()])
+    }
+
+    /// Do a getgid() syscall
+    fn getgid(&mut self) -> Result {
+        self.trace("getgid", 0);
+        Ok([FAKE_GID.into(), 0.into()])
+    }
+
+    /// Do a geteuid() syscall
+    fn geteuid(&mut self) -> Result {
+        self.trace("geteuid", 0);
+        Ok([FAKE_UID.into(), 0.into()])
+    }
+
+    /// Do a getegid() syscall
+    fn getegid(&mut self) -> Result {
+        self.trace("getegid", 0);
+        Ok([FAKE_GID.into(), 0.into()])
+    }
+
+    /// Do close syscall
+    fn close(&mut self, fd: libc::c_int) -> Result {
+        self.trace("close", 1);
+        unsafe { self.proxy(request!(libc::SYS_close => fd)) }
+    }
+}

--- a/internal/untrusted/Cargo.toml
+++ b/internal/untrusted/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "untrusted"
+version = "0.1.0"
+authors = ["Harald Hoyer <harald@redhat.com>"]
+license = "Apache-2.0"
+edition = "2018"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+primordial = "0.1"

--- a/internal/untrusted/LICENSE
+++ b/internal/untrusted/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/internal/untrusted/src/lib.rs
+++ b/internal/untrusted/src/lib.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! New Types to handle verified addresses
+
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![cfg_attr(not(test), no_std)]
+
+use core::convert::TryInto;
+use core::marker::PhantomData;
+use core::mem::{align_of, size_of};
+use primordial::Register;
+
+/// Trait to validate `self` with an `AddressValidator`
+pub trait Validate {
+    /// The output type
+    type Output;
+
+    /// validate `self` with an `AddressValidator`
+    ///
+    /// returns `None`, if `self` is not valid
+    fn validate<V: AddressValidator>(self, validator: &V) -> Option<Self::Output>;
+}
+
+/// Trait to validate `self` with an `AddressValidator`
+pub trait ValidateSlice {
+    /// The output type
+    type Output;
+
+    /// validate a slice for `self` and `length` with an `AddressValidator`
+    ///
+    /// returns `None`, if `self` is not valid
+    fn validate_slice<I: TryInto<usize>, V: AddressValidator>(
+        self,
+        length: I,
+        validator: &V,
+    ) -> Option<Self::Output>;
+}
+
+/// Factory for validated address references
+pub trait AddressValidator {
+    /// validator test function
+    ///
+    /// Returns `true`, if the memory is readable
+    fn validate_const_mem_fn(&self, ptr: *const (), size: usize) -> bool;
+
+    /// validator function
+    ///
+    /// Returns `true`, if the memory is readable and writable
+    fn validate_mut_mem_fn(&self, ptr: *mut (), size: usize) -> bool;
+}
+
+/// A reference to a user space object
+///
+/// Uses `*const` so, that it does not implement `Send` and `Sync`
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+pub struct UntrustedRef<'a, T>(*const T, PhantomData<&'a T>);
+
+impl<'a, T> UntrustedRef<'a, T> {
+    /// Get a pointer
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self.0 as _
+    }
+}
+
+impl<'a, T> From<*const T> for UntrustedRef<'a, T> {
+    fn from(data: *const T) -> Self {
+        Self(data, PhantomData::default())
+    }
+}
+
+impl<'a, T, U> From<Register<U>> for UntrustedRef<'a, T>
+where
+    usize: From<Register<U>>,
+{
+    fn from(data: Register<U>) -> Self {
+        Self(usize::from(data) as _, PhantomData::default())
+    }
+}
+
+impl<'a, T> Validate for UntrustedRef<'a, T> {
+    type Output = &'a T;
+
+    fn validate<V: AddressValidator>(self, validator: &V) -> Option<Self::Output> {
+        if self.0.is_null() {
+            return None;
+        }
+
+        // check for alignment
+        if self.0 as usize % align_of::<T>() != 0 {
+            return None;
+        }
+
+        // check for accessibility
+        if !validator.validate_const_mem_fn(self.0 as _, size_of::<T>()) {
+            return None;
+        }
+
+        Some(unsafe { &*self.0 })
+    }
+}
+
+impl<'a, T> ValidateSlice for UntrustedRef<'a, T> {
+    type Output = &'a [T];
+
+    fn validate_slice<I: TryInto<usize>, V: AddressValidator>(
+        self,
+        length: I,
+        validator: &V,
+    ) -> Option<Self::Output> {
+        let length = match length.try_into() {
+            Ok(val) => val,
+            Err(_) => return None,
+        };
+
+        if self.0.is_null() {
+            return None;
+        }
+
+        // check for alignment
+        if self.0 as usize % align_of::<T>() != 0 {
+            return None;
+        }
+
+        // check for accessibility
+        if !validator.validate_const_mem_fn(self.0 as _, size_of::<T>() * length) {
+            return None;
+        }
+
+        Some(unsafe { core::slice::from_raw_parts(self.0, length) })
+    }
+}
+
+/// A mutable reference to a user space object
+///
+/// Uses `*mut` so, that it does not implement `Send` and `Sync`
+#[repr(transparent)]
+pub struct UntrustedRefMut<'a, T>(*mut T, PhantomData<&'a mut T>);
+
+impl<'a, T> UntrustedRefMut<'a, T> {
+    /// Get a pointer
+    #[inline]
+    pub fn as_ptr(&self) -> *const T {
+        self.0 as _
+    }
+
+    /// Get a mutable pointer
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.0 as _
+    }
+}
+
+impl<'a, T> From<*mut T> for UntrustedRefMut<'a, T> {
+    fn from(data: *mut T) -> Self {
+        Self(data, PhantomData::default())
+    }
+}
+
+impl<'a, T, U> From<Register<U>> for UntrustedRefMut<'a, T>
+where
+    usize: From<Register<U>>,
+{
+    fn from(data: Register<U>) -> Self {
+        Self(usize::from(data) as _, PhantomData::default())
+    }
+}
+
+impl<'a, T> Validate for UntrustedRefMut<'a, T> {
+    type Output = &'a mut T;
+
+    fn validate<V: AddressValidator>(self, validator: &V) -> Option<Self::Output> {
+        if self.0.is_null() {
+            return None;
+        }
+
+        // check for alignment
+        if self.0 as usize % align_of::<T>() != 0 {
+            return None;
+        }
+
+        // check for accessibility
+        if !validator.validate_mut_mem_fn(self.0 as _, size_of::<T>()) {
+            return None;
+        }
+
+        Some(unsafe { &mut *self.0 })
+    }
+}
+
+impl<'a, T> ValidateSlice for UntrustedRefMut<'a, T> {
+    type Output = &'a mut [T];
+
+    fn validate_slice<I: TryInto<usize>, V: AddressValidator>(
+        self,
+        length: I,
+        validator: &V,
+    ) -> Option<Self::Output> {
+        let length = match length.try_into() {
+            Ok(val) => val,
+            Err(_) => return None,
+        };
+
+        if self.0.is_null() {
+            return None;
+        }
+
+        // check for alignment
+        if self.0 as usize % align_of::<T>() != 0 {
+            return None;
+        }
+
+        // check for accessibility
+        if !validator.validate_mut_mem_fn(self.0 as _, size_of::<T>() * length) {
+            return None;
+        }
+
+        Some(unsafe { core::slice::from_raw_parts_mut(self.0, length) })
+    }
+}


### PR DESCRIPTION
* feat(untrusted): Add untrusted crate
    
    Adds a crate to validate
    * `const *T`
    * `mut *T`
    * `const *[T]`
    * `mut *[T]`
    
    by checking the alignment and calling out to a shim specific
    validator method, which should check, if the referenced memory
    is in a valid address space.
    
    Resolves: https://github.com/enarx/enarx/issues/630
    Related: https://github.com/enarx/enarx-keepldr/issues/78
    
* feat(syscall): Add syscall crate
    
    This crate unifies the syscall infrastructure in a common trait shared
    between shims. An implementation of the `SyscallHandler` trait has to
    implement the empty syscalls and can overwrite pre-implemented syscalls
    with an optimized version.
    
    This crate also should hold any Enarx specific syscall constants and type
    definitions.
    
* refactor(shims): Use untrusted and syscall crates
    
    Let `shim-sgx` and `shim-sev` make use of the `untrusted` and `syscall` crate,
    which removes duplicate code and unifies the syscall handling across shims.
    
* feat(shim-sev): Implement missing `arch_prctl` operations
    
    This patch implements the missing `arch_prctl` operations:
    - ARCH_GET_FS
    - ARCH_SET_GS
    - ARCH_GET_GS

