### PR TITLE
Stub in shim --> host implementation of get_att() for SGX

### DIFF
--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -192,7 +192,13 @@ impl SyscallHandler for Handler {
         eprintln!(")");
     }
 
-    fn get_attestation(&mut self) -> sallyport::Result {
+    fn get_attestation(
+        &mut self,
+        _nonce: UntrustedRef<u8>,
+        _nonce_len: libc::size_t,
+        _buf: UntrustedRefMut<u8>,
+        _buf_len: libc::size_t,
+    ) -> sallyport::Result {
         self.trace("get_att", 0);
         Ok([0.into(), SEV_TECH.into()])
     }

--- a/internal/syscall/src/lib.rs
+++ b/internal/syscall/src/lib.rs
@@ -74,7 +74,13 @@ pub trait SyscallHandler: AddressValidator + Sized {
     fn trace(&mut self, name: &str, argc: usize);
 
     /// Enarx syscall - get attestation
-    fn get_attestation(&mut self) -> Result;
+    fn get_attestation(
+        &mut self,
+        nonce: UntrustedRef<u8>,
+        nonce_len: libc::size_t,
+        buf: UntrustedRefMut<u8>,
+        buf_len: libc::size_t,
+    ) -> Result;
 
     /// syscall
     fn exit(&mut self, status: libc::c_int) -> !;
@@ -168,7 +174,7 @@ pub trait SyscallHandler: AddressValidator + Sized {
             libc::SYS_geteuid => self.geteuid(),
             libc::SYS_getegid => self.getegid(),
 
-            SYS_GETATT => self.get_attestation(),
+            SYS_GETATT => self.get_attestation(a.into(), b.into(), c.into(), d.into()),
 
             _ => Err(libc::ENOSYS),
         };

--- a/src/backend/sgx/attestation.rs
+++ b/src/backend/sgx/attestation.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{Error, ErrorKind};
+use std::slice::from_raw_parts_mut;
+
+const QUOTE_SIZE: usize = 512; // TODO: Determine length of Quote of PCK cert type
+const TI_SIZE: usize = 512;
+const TMP_TI: [u8; TI_SIZE] = [32u8; TI_SIZE];
+const TMP_QUOTE: [u8; QUOTE_SIZE] = [44u8; QUOTE_SIZE];
+
+/// Returns either the size required for the output buffer, or the number of bytes written to the
+/// output buffer. Depending on parameters, the output buffer will be filled with the Target Info
+/// for the QE, or a Quote verifying a Report.
+pub fn get_attestation(
+    nonce: usize,
+    _nonce_len: usize,
+    buf: usize,
+    buf_len: usize,
+) -> Result<usize, Error> {
+    // If the nonce is 0 (NULL), fills the Target Info of the QE into the output buffer
+    // and returns the number of bytes written.
+    if nonce == 0 {
+        // TODO: Populate with real Target Info (https://github.com/enarx/enarx-keepldr/issues/92).
+        let b: &mut [u8] = unsafe { from_raw_parts_mut(buf as *mut u8, buf_len) };
+
+        if b.len() != TMP_TI.len() {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "Unable to copy TargetInfo to buffer",
+            ));
+        } else {
+            b.copy_from_slice(&TMP_TI);
+            return Ok(TI_SIZE);
+        }
+
+    // If the nonce in not 0, fills the Quote obtained from the AESMD for the report
+    // specified in the nonce field into the output buffer and returns the number of
+    // bytes written.
+    } else {
+        // NOTE: Fill this in with real implementation calling out to AESMD
+        // (https://github.com/enarx/enarx-keepldr/issues/92).
+        let b: &mut [u8] = unsafe { from_raw_parts_mut(buf as *mut u8, buf_len) };
+
+        if b.len() != TMP_QUOTE.len() {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "Unable to copy Quote to buffer",
+            ));
+        } else {
+            b.copy_from_slice(&TMP_QUOTE);
+            return Ok(QUOTE_SIZE);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const REPORT_SIZE: usize = 512; // TODO: Determine length of Report
+
+    #[test]
+    fn req_ti() {
+        let output = [1u8; TI_SIZE];
+        assert_eq!(
+            get_attestation(0, 0, output.as_ptr() as usize, output.len()).unwrap(),
+            TI_SIZE
+        );
+        assert_eq!(output, TMP_TI);
+    }
+
+    #[test]
+    fn req_quote() {
+        let input = [1u8; REPORT_SIZE];
+        let output = [1u8; QUOTE_SIZE];
+        assert_eq!(
+            get_attestation(
+                input.as_ptr() as usize,
+                input.len(),
+                output.as_ptr() as usize,
+                output.len()
+            )
+            .unwrap(),
+            QUOTE_SIZE
+        );
+        assert_eq!(output, TMP_QUOTE);
+    }
+}

--- a/tests/bin/sgx_get_att_quote.c
+++ b/tests/bin/sgx_get_att_quote.c
@@ -1,0 +1,30 @@
+#include "libc.h"
+#include <errno.h>
+
+/* This test will be run only for SGX. It is designed to request a
+ * Quote from get_attestation() and check that the first bytes of
+ * the returned Quote in buf match expected values. */
+
+// TODO: Update these to match real Quote values.
+// See https://github.com/enarx/enarx-keepldr/issues/92.
+const unsigned char expected[512] = { 44, 44, 44 };
+
+int main(void) {
+    int* nonce = NULL;
+    // TODO Update this buffer size to match real Quote.
+    unsigned char buf[512];
+    size_t technology;
+    int i;
+
+    ssize_t size = get_att(nonce, sizeof(nonce), buf, sizeof(buf), &technology);
+
+    if ((size < 0) || (technology != 2))
+        return 1;
+
+    for (i = 0; i < 3; i++) {
+        if (buf[i] != expected[i])
+	    return 1;
+    }
+
+    return 0;
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -181,6 +181,12 @@ fn get_att() {
     run_test("get_att", 0, None, None, None);
 }
 
+#[cfg(feature = "backend-sgx")]
+#[test]
+fn sgx_get_att_quote() {
+    run_test("sgx_get_att_quote", 0, None, None, None);
+}
+
 #[test]
 #[serial]
 fn getuid() {


### PR DESCRIPTION
Closes #91 

This PR:
- Updates the function signature for `get_attestation()` in the internal `syscall` mod, the sev handler, and the sgx handler to pass the four parameters mentioned in #31 .
- Adds logic in the SGX shim handler to make two calls out to the host before returning a Quote to the code layer: one to request a TargetInfo from the host, and the second to request a Quote from the host. The first is a necessary prerequisite for the second.
- Adds an attestation mod in the sgx backend on the host side to handle proxied `get_att()` syscalls from the sgx shim. This currently returns synthetic values, but will communicate with the AESM daemon to get real TargetInfo and Quote values in the next PR.
- Adds logic in the sgx backend mod to route `get_att()` syscalls to the above attestation mod.
- Adds a test to request a Quote and check for expected values in the returned synthetic Quote.