### PR TITLE
fix(sallyport): Don't hardcode dup'ed file descriptor value

### DIFF
--- a/src/sallyport/mod.rs
+++ b/src/sallyport/mod.rs
@@ -378,11 +378,11 @@ mod tests {
         // Test dup() success.
         let req = request!(libc::SYS_dup => 0usize);
         let rep = unsafe { req.syscall() };
-        let res = Result::from(rep).unwrap()[0].into();
-        assert_eq!(3usize, res);
+        let dup_fd: usize = Result::from(rep).unwrap()[0].into();
+        assert!(dup_fd > 0);
 
         // Test close() success.
-        let req = request!(libc::SYS_close => 3usize);
+        let req = request!(libc::SYS_close => dup_fd);
         let rep = unsafe { req.syscall() };
         let res = Result::from(rep).unwrap()[0].into();
         assert_eq!(0usize, res);


### PR DESCRIPTION
If additional filedescriptors are open, the `syscall` test fails,
because it assumes, that the return value of dup() is 3.

This patch removes the hardcoded value and checks,
if the return value is greater 0 and then closes the dup'ed fd.

Fixes: https://github.com/enarx/enarx-keepldr/issues/135

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
