### PR TITLE
fix(shim-sev): Prepend syscall trace args with `0x`

### DIFF
--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -186,7 +186,7 @@ impl SyscallHandler for Handler {
         eprint!("{}(", name);
         for (i, arg) in self.argv[..argc].iter().copied().enumerate() {
             let prefix = if i > 0 { ", " } else { "" };
-            eprint!("{}0x{:x}", prefix, arg);
+            eprint!("{}{:#x}", prefix, arg);
         }
 
         eprintln!(")");


### PR DESCRIPTION
To clarify the hex output, prepend the hex numbers with `0x`.

Use the rust format parameter instead of manually specify `0x`

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
