### PR TITLE
fix(shim-sev): Output address in hex on panic in get_virt_offset

### DIFF
--- a/internal/shim-sev/src/frame_allocator.rs
+++ b/internal/shim-sev/src/frame_allocator.rs
@@ -210,7 +210,7 @@ impl FrameAllocator {
             for i in free.ent.iter() {
                 if i.start == 0 {
                     panic!(
-                        "Trying to get virtual offset from unmmapped location {:#?}",
+                        "Trying to get virtual offset from unmmapped location {:#x}",
                         addr
                     );
                 }


### PR DESCRIPTION
For better debugging, output the address in the panic message in
hexadecimal form.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
