### PR TITLE
fix(sallyport): Remove obsolete doc section

### DIFF
--- a/internal/sallyport/src/lib.rs
+++ b/internal/sallyport/src/lib.rs
@@ -8,9 +8,4 @@
 #![deny(clippy::all)]
 #![cfg_attr(not(test), no_std)]
 
-//! The `proxy` module contains structures used to facilitate communication between
-//! the microkernel and the hypervisor. This is referred to as "proxying" in the
-//! project literature. This is a very thin and low-level layer that is meant to
-//! be as transparent as possible.
-
 include!("../../../src/sallyport/mod.rs");


### PR DESCRIPTION
This doc section seems to be a leftover, when some module was called `proxy`.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
