### PR TITLE
fix(syscall): Use correct pointer for clock_gettime

### DIFF
--- a/internal/syscall/src/lib.rs
+++ b/internal/syscall/src/lib.rs
@@ -401,7 +401,7 @@ pub trait SyscallHandler: AddressValidator + Sized {
         let c = self.new_cursor();
 
         let (_, buf) = c.alloc::<libc::timespec>(1).or(Err(libc::EMSGSIZE))?;
-        let buf = buf.as_ptr();
+        let buf = buf[0].as_ptr();
         let host_virt = self.translate_shim_to_host_addr(buf);
 
         let result =


### PR DESCRIPTION
While the address of the whole array should be the same
as the first element, don't make such assumptions and
use the pointer of the first element.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
