### PR TITLE
Fix the sallyport blocksize

### DIFF
--- a/internal/syscall/src/lib.rs
+++ b/internal/syscall/src/lib.rs
@@ -9,7 +9,7 @@
 use core::convert::TryInto;
 use core::mem::MaybeUninit;
 use primordial::Register;
-use sallyport::{request, Cursor, Request, Result};
+use sallyport::{request, Block, Cursor, Request, Result};
 use untrusted::{AddressValidator, UntrustedRef, UntrustedRefMut, Validate, ValidateSlice};
 
 /// `get_attestation` syscall number
@@ -192,6 +192,9 @@ pub trait SyscallHandler: AddressValidator + Sized {
 
         let c = self.new_cursor();
 
+        // Limit the read to `Block::buf_capacity()`
+        let count = usize::min(count, Block::buf_capacity());
+
         let (_, hostbuf) = c.alloc::<u8>(count).or(Err(libc::EMSGSIZE))?;
         let hostbuf = hostbuf.as_ptr();
         let host_virt = self.translate_shim_to_host_addr(hostbuf);
@@ -205,7 +208,7 @@ pub trait SyscallHandler: AddressValidator + Sized {
         }
 
         let c = self.new_cursor();
-        c.copy_into_slice(count, buf.as_mut(), result_len)
+        c.copy_into_slice(count, buf[..count].as_mut(), result_len)
             .or(Err(libc::EFAULT))?;
 
         Ok(ret)
@@ -234,6 +237,9 @@ pub trait SyscallHandler: AddressValidator + Sized {
 
     /// syscall
     fn write(&mut self, fd: libc::c_int, buf: UntrustedRef<u8>, count: libc::size_t) -> Result {
+        // Limit the write to `Block::buf_capacity()`
+        let count = usize::min(count, Block::buf_capacity());
+
         let buf = buf.validate_slice(count, self).ok_or(libc::EFAULT)?;
 
         let c = self.new_cursor();
@@ -242,6 +248,13 @@ pub trait SyscallHandler: AddressValidator + Sized {
         let host_virt = self.translate_shim_to_host_addr(buf);
 
         let ret = unsafe { self.proxy(request!(libc::SYS_write => fd, host_virt, count))? };
+
+        let result_len: usize = ret[0].into();
+
+        if result_len > count {
+            self.attacked()
+        }
+
         Ok(ret)
     }
 
@@ -257,8 +270,19 @@ pub trait SyscallHandler: AddressValidator + Sized {
         let mut size = 0usize;
 
         for vec in iovec {
-            size +=
+            let written =
                 usize::from(self.write(fd, (vec.iov_base as *const u8).into(), vec.iov_len)?[0]);
+
+            if written > vec.iov_len {
+                self.attacked();
+            }
+
+            size += written;
+
+            if written != vec.iov_len {
+                // There was a short write, let userspace retry.
+                break;
+            }
         }
 
         Ok([size.into(), 0.into()])

--- a/tests/bin/read_udp.c
+++ b/tests/bin/read_udp.c
@@ -1,0 +1,15 @@
+// Read and write a buffer of the size of a maximum sized UDP packet
+// in one go and fail, if it was fragmented.
+
+#include "libc.h"
+
+int main(void) {
+    char buf[65507];
+
+    ssize_t out = read(STDIN_FILENO, buf, sizeof(buf));
+
+    if (out != sizeof(buf))
+        return -1;
+
+    write(STDOUT_FILENO, buf, out);
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -174,11 +174,26 @@ fn readv() {
 #[test]
 #[serial]
 fn echo() {
-    let mut input: Vec<u8> = Vec::with_capacity(4096);
+    let mut input: Vec<u8> = Vec::with_capacity(2 * 1024 * 1024);
+
     for i in 0..input.capacity() {
         input.push(i as _);
     }
     run_test("echo", 0, input.as_slice(), input.as_slice(), None);
+}
+
+#[test]
+#[serial]
+fn read_udp() {
+    // The maximum UDP message size is 65507, as determined by the following formula:
+    // 0xffff - (sizeof(minimal IP Header) + sizeof(UDP Header)) = 65535-(20+8) = 65507
+    const MAX_UDP_PACKET_SIZE: usize = 65507;
+
+    let mut input: Vec<u8> = Vec::with_capacity(MAX_UDP_PACKET_SIZE);
+    for i in 0..input.capacity() {
+        input.push(i as _);
+    }
+    run_test("read_udp", 0, input.as_slice(), input.as_slice(), None);
 }
 
 #[test]


### PR DESCRIPTION
*   fix(syscall): Read/Write in chunks of Block::buf_capacity
    
    Read and Write from the host in chunks of `Block::buf_capacity()`,
    if the requested length is greater.
    While this might cause problems with blocking file descriptors,
    it is very unlikely though.
   
*   fix(sallyport): Fix the sallyport block size
    
    The sallyport block size was set 512 * 4096 bytes, whereas
    the space was never allocated in the kvm backend.
    
    This patch sets the capacity to hold at least a maximum UDP packet.
    
    When multi-threading is implemented multiple buffers need to be
    available for concurrent syscalls.
    Related: https://github.com/enarx/enarx-keepldr/issues/156
    
    Fixes: https://github.com/enarx/enarx-keepldr/issues/23

*   feat(tests): Add read_udp test
    
    This test tries to read 65507 in one go.
    It fails, if there was a short read.
    
    While this test does not explicitly tests, if the shim has
    proxied this to the host with length 65507, an strace shows
    that it has.
    
    A future PR will change this to use real UDP.
    Related: https://github.com/enarx/enarx-keepldr/issues/154
    
    To test, if bigger reads can be still processed, increase
    the `echo` test size to 2MB.    