### PR TITLE
Serialize integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "codicon"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +213,7 @@ dependencies = [
  "nbytes",
  "primordial",
  "process_control",
+ "serial_test",
  "sev",
  "sgx",
  "structopt",
@@ -305,6 +315,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
+name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +378,30 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+dependencies = [
+ "cfg-if",
+ "cloudabi",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -471,6 +514,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "scroll"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +533,28 @@ name = "scroll_derive"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e367622f934864ffa1c704ba2b82280aab856e3d8213c84c5720257eb34b15b9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b15f74add9a9d4a3eb2bf739c9a427d266d3895b53d992c3a7c234fec2ff1f1"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65f59259be9fc1bf677d06cc1456e97756004a1a5a577480f71430bd7c17ba33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -519,6 +590,12 @@ dependencies = [
  "vdso",
  "xsave",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,4 @@ walkdir = "2"
 
 [dev-dependencies]
 process_control = "2.0"
+serial_test = "0.5"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8,6 +8,7 @@ use std::slice::from_raw_parts_mut;
 use std::time::Duration;
 
 use process_control::{ChildExt, Output, Timeout};
+use serial_test::serial;
 
 const CRATE: &str = env!("CARGO_MANIFEST_DIR");
 const KEEP_BIN: &str = env!("CARGO_BIN_EXE_enarx-keepldr");
@@ -89,16 +90,19 @@ fn read_item<T: Copy>(mut rdr: impl Read) -> std::io::Result<T> {
 }
 
 #[test]
+#[serial]
 fn exit_zero() {
     run_test("exit_zero", 0, None, None, None);
 }
 
 #[test]
+#[serial]
 fn exit_one() {
     run_test("exit_one", 1, None, None, None);
 }
 
 #[test]
+#[serial]
 fn clock_gettime() {
     use libc::{clock_gettime, CLOCK_MONOTONIC};
 
@@ -127,16 +131,19 @@ fn clock_gettime() {
 }
 
 #[test]
+#[serial]
 fn write_stdout() {
     run_test("write_stdout", 0, None, &b"hi\n"[..], None);
 }
 
 #[test]
+#[serial]
 fn write_stderr() {
     run_test("write_stderr", 0, None, None, &b"hi\n"[..]);
 }
 
 #[test]
+#[serial]
 // FIXME this should not be ignored, this was applied as part
 // of a commit that must be reverted and implemented properly.
 #[ignore]
@@ -145,18 +152,21 @@ fn write_emsgsize() {
 }
 
 #[test]
+#[serial]
 fn read() {
     const INPUT: &[u8; 12] = b"hello world\n";
     run_test("read", 0, &INPUT[..], &INPUT[..], None);
 }
 
 #[test]
+#[serial]
 fn readv() {
     const INPUT: &[u8; 36] = b"hello, worldhello, worldhello, world";
     run_test("readv", 0, &INPUT[..], &INPUT[..], None);
 }
 
 #[test]
+#[serial]
 fn echo() {
     let mut input: Vec<u8> = Vec::with_capacity(4096);
     for i in 0..input.capacity() {
@@ -166,26 +176,31 @@ fn echo() {
 }
 
 #[test]
+#[serial]
 fn get_att() {
     run_test("get_att", 0, None, None, None);
 }
 
 #[test]
+#[serial]
 fn getuid() {
     run_test("getuid", 0, None, None, None);
 }
 
 #[test]
+#[serial]
 fn geteuid() {
     run_test("geteuid", 0, None, None, None);
 }
 
 #[test]
+#[serial]
 fn getgid() {
     run_test("getgid", 0, None, None, None);
 }
 
 #[test]
+#[serial]
 fn getegid() {
     run_test("getegid", 0, None, None, None);
 }


### PR DESCRIPTION
The more tests we add the more pressure we're putting on the
SEV launch process. Let's serialize them to avoid spurrious
failures, otherwise we'll just be playing a game of adjusting
the timeout again and again.

edit: I'll be looking into ways to hasten the launch process as well.
I have a hunch that #134 might help... not sure.

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>
