### PR TITLE
Prepare some small changes for SGX attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,8 @@ dependencies = [
  "nbytes",
  "primordial",
  "process_control",
+ "protobuf",
+ "protobuf-codegen-pure",
  "serial_test",
  "sev",
  "sgx",
@@ -467,6 +469,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "2.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d147edb77bcccbfc81fabffdc7bd50c13e103b15ca1e27515fe40de69a5776b"
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e81f70c25aab9506f87253c55f7cdcd8917635d5597382958d20025c211bbbd"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "protobuf-codegen-pure"
+version = "2.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af8d72d9e14fd41a954f4d5b310396151437c83d2bfcbf19d3073af90e46288"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,7 +604,7 @@ dependencies = [
 [[package]]
 name = "sgx"
 version = "0.1.0"
-source = "git+https://github.com/enarx/sgx?rev=512e077#512e077654ddecc7ca25690b31fc25de9f4b2870"
+source = "git+https://github.com/enarx/sgx?rev=5292e53#5292e53679a29099d3c2570e2bcb66c9a84de0fd"
 dependencies = [
  "bitflags",
  "cc",
@@ -629,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,12 @@ anyhow = "1.0"
 goblin = "0.2"
 libc = "0.2"
 lset = "0.1"
+protobuf = "2.18"
 
 [build-dependencies]
 cc = "1.0"
 walkdir = "2"
+protobuf-codegen-pure = "2.3"
 
 [dev-dependencies]
 process_control = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ backend-sgx = ["sgx"]
 
 [dependencies]
 sev = { git = "https://github.com/enarx/sev", features = ["openssl"], optional = true }
-sgx = { git = "https://github.com/enarx/sgx", rev = "512e077", features = ["asm", "crypto"], optional = true }
+sgx = { git = "https://github.com/enarx/sgx", rev = "5292e53", features = ["asm", "crypto"], optional = true }
 x86_64 = { version = "0.11", default-features = false, features = ["stable"], optional = true }
 kvm-bindings = { version = "0.3", optional = true }
 kvm-ioctls = { version = "0.5", optional = true }

--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
 [[package]]
 name = "sgx"
 version = "0.1.0"
-source = "git+https://github.com/enarx/sgx?rev=512e077#512e077654ddecc7ca25690b31fc25de9f4b2870"
+source = "git+https://github.com/enarx/sgx?rev=5292e53#5292e53679a29099d3c2570e2bcb66c9a84de0fd"
 dependencies = [
  "bitflags",
  "cc",

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -16,7 +16,7 @@ sgx-heap = { path = "../sgx-heap" }
 syscall = { path = "../syscall"}
 untrusted = { path = "../untrusted"}
 compiler_builtins = { version = "0.1", default-features = false, features = [ "mem" ] }
-sgx = { git = "https://github.com/enarx/sgx", rev = "512e077" }
+sgx = { git = "https://github.com/enarx/sgx", rev = "5292e53" }
 goblin = { version = "0.2", default-features = false, features = [ "elf64" ] }
 crt0stack = { version = "0.1", default-features = false }
 libc = { version = "0.2", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,7 @@
 
 mod backend;
 mod binary;
+mod protobuf;
 mod sallyport;
 
 // workaround for sallyport tests, until we have internal crates

--- a/src/protobuf/aesm-proto.proto
+++ b/src/protobuf/aesm-proto.proto
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2011-2020 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+syntax = "proto2";
+package aesm.message;
+option optimize_for = LITE_RUNTIME;
+
+message Request{
+
+    message InitQuoteRequest{
+        optional    uint32  timeout         = 9;
+    }
+
+    message GetQuoteRequest{
+        required    bytes report            = 1;
+        required    uint32 quote_type       = 2;
+        required    bytes spid              = 3;
+        optional    bytes nonce             = 4;
+        optional    bytes sig_rl            = 5;
+        required    uint32 buf_size         = 6;
+        optional    bool qe_report          = 7;
+        optional    uint32  timeout         = 9;
+    }
+
+    message GetLaunchTokenRequest{
+        required    bytes mr_enclave        = 1;
+        required    bytes mr_signer         = 2;
+        required    bytes se_attributes     = 3;
+        optional    uint32  timeout         = 9;
+    }
+
+    message ReportAttestationErrorRequest{
+        required    bytes platform_info             = 1;
+        required    uint32 attestation_error_code   = 2;
+        required    uint32 update_info_size         = 3;
+        optional    uint32  timeout                 = 9;
+    }
+
+    message CheckUpdateStatusRequest{
+        optional    bytes platform_info             = 1;
+        required    uint32 update_info_size         = 2;
+        required    uint32 config                   = 3;
+        optional    uint32  timeout                 = 9;
+    }
+
+    message GetWhiteListSizeRequest{
+        optional    uint32  timeout         = 9;
+    }
+
+    message GetWhiteListRequest{
+        optional    uint32  white_list_size = 1;
+        optional    uint32  timeout         = 9;
+    }
+
+    message SGXGetExtendedEpidGroupIdRequest{
+        optional    uint32  timeout         = 9;
+    }
+
+    message SGXSwitchExtendedEpidGroupRequest{
+        optional    uint32  x_group_id      = 1;
+        optional    uint32  timeout         = 9;
+    }
+
+    message SGXRegisterRequest{
+        required    bytes   buf             = 1;
+        required    uint32  data_type       = 2;
+        optional    uint32  timeout         = 9;
+    }
+
+    message InitQuoteExRequest{
+        optional    bytes  att_key_id              = 1;
+        required    bool   b_pub_key_id            = 3;
+        optional    uint64 buf_size                = 4;
+        optional    uint32 timeout                 = 9;
+    }
+
+    message SelectAttKeyIDRequest{
+        optional    bytes  att_key_id_list         = 1;
+        optional    uint32  timeout                = 2;
+    }
+
+    message GetQuoteSizeExRequest{
+        optional    bytes   att_key_id             = 1;
+        optional    uint32  timeout                = 9;
+    }
+
+    message GetQuoteExRequest{
+        required    bytes   report          = 1;
+        optional    bytes   att_key_id      = 2;
+        optional    bytes   qe_report_info  = 3;
+        required    uint32  buf_size        = 4;
+        optional    uint32  timeout         = 9;
+    }
+
+    optional    InitQuoteRequest initQuoteReq                 = 1;
+    optional    GetQuoteRequest getQuoteReq                   = 2;
+    optional    GetLaunchTokenRequest getLicTokenReq          = 3;
+    optional    ReportAttestationErrorRequest   reportErrReq  = 4;
+    optional    GetWhiteListSizeRequest getWhiteListSizeReq   = 10;
+    optional    GetWhiteListRequest getWhiteListReq           = 11;
+    optional    SGXGetExtendedEpidGroupIdRequest sgxGetExtendedEpidGroupIdReq   = 12;
+    optional    SGXSwitchExtendedEpidGroupRequest sgxSwitchExtendedEpidGroupReq = 13;
+    optional    SGXRegisterRequest sgxRegisterReq             = 14;
+    optional    InitQuoteExRequest initQuoteExReq             = 15;
+    optional    GetQuoteSizeExRequest getQuoteSizeExReq       = 16;
+    optional    GetQuoteExRequest getQuoteExReq               = 17;
+    optional    CheckUpdateStatusRequest checkUpdateStatusReq = 18;
+    optional    SelectAttKeyIDRequest selectAttKeyIDReq       = 19;
+}
+
+message Response{
+
+    message InitQuoteResponse{
+        required    uint32  errorCode   = 1 [default = 1];
+        optional    bytes targetInfo    = 2;
+        optional    bytes gid           = 3;
+    }
+
+    message GetQuoteResponse{
+        required    uint32 errorCode    = 1 [default = 1];
+        optional    bytes quote         = 2;
+        optional    bytes qe_report     = 3;
+    }
+
+    message GetLaunchTokenResponse{
+        required    uint32 errorCode    = 1 [default = 1];
+        optional    bytes token         = 2;
+    }
+
+    message ReportAttestationErrorResponse{
+        required   uint32 errorCode             = 1 [default = 1];
+        optional   bytes platform_update_info   = 2;
+    }
+    
+    message CheckUpdateStatusResponse{
+        required   uint32 errorCode             = 1 [default = 1];
+        optional   bytes platform_update_info   = 2;
+        optional   uint32 status                 = 3;
+    }
+
+    message GetWhiteListSizeResponse{
+        required   uint32 errorCode = 1 [default = 1];
+        optional   uint32 white_list_size = 2;
+    }
+
+    message GetWhiteListResponse{
+        required   uint32 errorCode = 1 [default = 1];
+        optional   bytes  white_list = 2;
+    }
+
+    message SGXGetExtendedEpidGroupIdResponse{
+        required   uint32 errorCode = 1 [default = 1];
+        optional   uint32 x_group_id = 2;
+    }
+
+    message SGXSwitchExtendedEpidGroupResponse{
+        required   uint32 errorCode = 1 [ default = 1];
+    }
+
+    message SGXRegisterResponse{
+        required   uint32 errorCode = 1 [ default = 1];
+    }
+
+    message SelectAttKeyIDResponse{
+        required    uint32 errorCode            = 1 [default = 1];
+        optional    bytes  selected_att_key_id  = 2;
+    }
+
+    message InitQuoteExResponse{
+        required    uint32 errorCode       = 1 [default = 1];
+        optional    bytes  target_info     = 2;
+        optional    uint64 pub_key_id_size = 3;
+        optional    bytes  pub_key_id      = 4;
+    }
+
+    message GetQuoteSizeExResponse{
+        required    uint32 errorCode    = 1 [default = 1];
+        optional    uint32 quote_size   = 2;
+    }
+	
+    message GetQuoteExResponse{
+        required    uint32 errorCode      = 1 [default = 1];
+        optional    bytes  quote          = 2;
+        optional    bytes  qe_report_info = 3;
+    }
+
+    optional    InitQuoteResponse initQuoteRes              = 1;
+    optional    GetQuoteResponse getQuoteRes                = 2;
+    optional    GetLaunchTokenResponse getLicTokenRes       = 3;
+    optional    ReportAttestationErrorResponse reportErrRes = 4;
+    optional    GetWhiteListSizeResponse getWhiteListSizeRes = 10;
+    optional    GetWhiteListResponse getWhiteListRes        = 11;
+    optional    SGXGetExtendedEpidGroupIdResponse sgxGetExtendedEpidGroupIdRes = 12;
+    optional    SGXSwitchExtendedEpidGroupResponse sgxSwitchExtendedEpidGroupRes = 13;
+    optional    SGXRegisterResponse sgxRegisterRes          = 14;
+    optional    InitQuoteExResponse initQuoteExRes          = 15;
+    optional    GetQuoteSizeExResponse getQuoteSizeExRes    = 16;
+    optional    GetQuoteExResponse getQuoteExRes            = 17;
+    optional    CheckUpdateStatusResponse checkUpdateStatusRes = 18;
+    optional    SelectAttKeyIDResponse selectAttKeyIDRes    = 19;
+}

--- a/src/protobuf/mod.rs
+++ b/src/protobuf/mod.rs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides all generated protobuf modules
+
+include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));


### PR DESCRIPTION
We will need an updated version of the SGX dependency and we'll need to use Intel's `aesm-proto` file to generate Rust structures during build.