### PR TITLE
feat(shim-sev): Use named parameters in asm! blocks

### DIFF
--- a/internal/shim-sev/src/main.rs
+++ b/internal/shim-sev/src/main.rs
@@ -74,13 +74,13 @@ pub fn get_cbit_mask() -> u64 {
 pub unsafe fn switch_shim_stack(ip: extern "C" fn() -> !, sp: u64) -> ! {
     assert_eq!(sp % 16, 0);
     asm!("
-        mov rsp, {0}
+        mov rsp, {SP}
         sub rsp, 8
         push rbp
-        call {1}
+        call {IP}
         ",
-        in(reg) sp,
-        in(reg) ip,
+        SP = in(reg) sp,
+        IP = in(reg) ip,
         options(noreturn, nomem)
     );
 }

--- a/internal/shim-sev/src/usermode.rs
+++ b/internal/shim-sev/src/usermode.rs
@@ -14,11 +14,11 @@ use x86_64::registers::rflags::RFlags;
 #[naked]
 pub unsafe fn usermode(ip: u64, sp: u64) -> ! {
     asm!("
-        push     {0}
-        push     {1}
-        push     {2}
-        push     {3}
-        push     {4}
+        push     {USER_DATA_SEGMENT}
+        push     {SP}
+        push     {RFLAGS}
+        push     {USER_CODE_SEGMENT}
+        push     {IP}
         xor      rax,                   rax
         xor      rbx,                   rbx
         xor      rcx,                   rcx
@@ -48,11 +48,11 @@ pub unsafe fn usermode(ip: u64, sp: u64) -> ! {
         # this sets the segments and rip from the stack
         iretq
           ",
-    const USER_DATA_SEGMENT,
-    in(reg) sp,
-    const RFlags::INTERRUPT_FLAG.bits(),
-    const USER_CODE_SEGMENT,
-    in(reg) ip,
+    USER_DATA_SEGMENT = const USER_DATA_SEGMENT,
+    SP = in(reg) sp,
+    RFLAGS = const RFlags::INTERRUPT_FLAG.bits(),
+    USER_CODE_SEGMENT = const USER_CODE_SEGMENT,
+    IP = in(reg) ip,
     options(noreturn, nomem)
     );
 }

--- a/internal/shim-sgx/src/entry.rs
+++ b/internal/shim-sgx/src/entry.rs
@@ -85,10 +85,10 @@ pub extern "C" fn entry(_rdi: u64, _rsi: u64, _rdx: u64, layout: &Layout, _r8: u
 
     unsafe {
         asm!(
-            "mov rsp, {}",
-            "jmp {}",
-            in(reg) &*handle,
-            in(reg) layout.code.start as u64 + hdr.e_entry,
+            "mov rsp, {SP}",
+            "jmp {START}",
+            SP = in(reg) &*handle,
+            START = in(reg) layout.code.start as u64 + hdr.e_entry,
             options(noreturn)
         )
     }


### PR DESCRIPTION
Named parameters make reading `asm!()` blocks a lot easier and are less
error prone to changes made in the arguments.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
