### PR TITLE
fix(shim-sev): Clear rcx and r11 on syscall return

### DIFF
--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -61,6 +61,9 @@ pub unsafe fn _syscall_enter() -> ! {
     # SYSCALL: rdi, rsi, rdx, r10, r8, r9 and syscall number in rax
     mov    rcx,                     r10
 
+    # These will be preserved by `syscall_rust` via the SYS-V ABI
+    # rbx, rsp, rbp, r12, r13, r14, r15
+
     # save registers
     push   rdi
     push   rsi
@@ -83,11 +86,14 @@ pub unsafe fn _syscall_enter() -> ! {
     pop    r8
     pop    r10
     pop    r11
-    add    rsp,                     0x8               # skip rdx
+    add    rsp,                     0x8               # skip rdx, because it is a return value
     pop    rsi
     pop    rdi
 
     pop    rbx
+
+    xor    rcx,                     rcx               # do not leak contents to userspace
+    xor    r11,                     r11               # do not leak contents to userspace
 
     swapgs                                            # restore gs
 


### PR DESCRIPTION
Do not leak the register contents of rcx and r11 to user space.

Also add more comments to clarify what is preserved by the called
function.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
