### PR TITLE
feat(shim-sev): Implement get_attestation for SEV

### DIFF
--- a/internal/shim-sev/src/attestation.rs
+++ b/internal/shim-sev/src/attestation.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! SEV attestation handling
+
+use crate::hostlib::{BootInfo, SevSecret, SEV_SECRET_MAX_SIZE};
+use crate::C_BIT_MASK;
+use core::hint::unreachable_unchecked;
+use core::sync::atomic::Ordering;
+use spinning::RwLock;
+
+/// A copy of the injected SEV secret.
+#[derive(Copy, Clone, Debug)]
+pub struct SevSecretCopy {
+    /// the secret byte blob
+    data: [u8; SEV_SECRET_MAX_SIZE],
+}
+
+/// The secret injected by the Hypervisor
+pub static SEV_SECRET: RwLock<SevSecretCopy> = RwLock::<SevSecretCopy>::const_new(
+    spinning::RawRwLock::const_new(),
+    SevSecretCopy {
+        data: [0u8; SEV_SECRET_MAX_SIZE],
+    },
+);
+
+impl SevSecretCopy {
+    #[allow(clippy::integer_arithmetic)]
+    unsafe fn cbor_len(data: *const u8) -> Option<usize> {
+        let prefix = data.read();
+
+        // only accept CBOR BYTES type
+        if (prefix >> 5) != 2 {
+            return None;
+        }
+
+        // mask the minor
+        match prefix & 0b00011111 {
+            x @ 0..=23 => Some(1 + x as usize),
+            24 => Some(1 + 1 + data.add(1).read() as usize),
+            25 => {
+                let data = data.add(1) as *const [u8; 2];
+                Some(1 + 2 + u16::from_be_bytes(data.read()) as usize)
+            }
+            26 => {
+                let data = data.add(1) as *const [u8; 4];
+                Some(1 + 4 + u32::from_be_bytes(data.read()) as usize)
+            }
+            27 => {
+                let data = data.add(1) as *const [u8; 8];
+                Some(1 + 8 + u64::from_be_bytes(data.read()) as usize)
+            }
+            28 => None,
+            29 => None,
+            30 => None,
+            31 => None,
+            32..=255 => unreachable_unchecked(),
+        }
+    }
+
+    /// get the length of the secret
+    pub fn try_len(&self) -> Option<usize> {
+        unsafe { SevSecretCopy::cbor_len(self.data.as_ptr()) }
+    }
+
+    /// Backup the secret injected by the Hypervisor
+    ///
+    /// # Safety
+    /// The caller has to ensure `boot_info` is pointing
+    /// to the initial BootInfo passed by the Hypervisor.
+    pub unsafe fn copy_from_bootinfo(&mut self, boot_info: *const BootInfo) {
+        if C_BIT_MASK.load(Ordering::Relaxed) == 0 {
+            return;
+        }
+
+        let secret_ptr = SevSecret::get_secret_ptr(boot_info);
+
+        let secret_len = match SevSecretCopy::cbor_len(secret_ptr as *const u8) {
+            None => return,
+            Some(len) => len,
+        };
+
+        if secret_len > SEV_SECRET_MAX_SIZE {
+            return;
+        }
+
+        core::ptr::copy_nonoverlapping::<u8>(
+            (*secret_ptr).data.as_ptr() as _,
+            self.data.as_mut_ptr(),
+            secret_len,
+        );
+    }
+
+    /// Get a slice of the secret
+    pub fn try_as_slice(&self) -> Option<&[u8]> {
+        self.try_len().map(|len| &self.data[..len])
+    }
+}

--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -4,6 +4,7 @@
 
 use crate::addr::{HostVirtAddr, ShimPhysUnencryptedAddr};
 use crate::asm::_enarx_asm_triple_fault;
+use crate::attestation::SEV_SECRET;
 use crate::eprintln;
 use crate::frame_allocator::FRAME_ALLOCATOR;
 use crate::hostcall::{self, HostCall, HOST_CALL};
@@ -16,7 +17,7 @@ use primordial::{Address, Register};
 use sallyport::{Cursor, Request};
 use spinning::MutexGuard;
 use syscall::{SyscallHandler, ARCH_GET_FS, ARCH_GET_GS, ARCH_SET_FS, ARCH_SET_GS, SEV_TECH};
-use untrusted::{AddressValidator, UntrustedRef, UntrustedRefMut, Validate};
+use untrusted::{AddressValidator, UntrustedRef, UntrustedRefMut, Validate, ValidateSlice};
 use x86_64::registers::{rdfsbase, rdgsbase, wrfsbase, wrgsbase};
 use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
 use x86_64::{align_up, VirtAddr};
@@ -205,11 +206,28 @@ impl SyscallHandler for Handler {
         &mut self,
         _nonce: UntrustedRef<u8>,
         _nonce_len: libc::size_t,
-        _buf: UntrustedRefMut<u8>,
-        _buf_len: libc::size_t,
+        buf: UntrustedRefMut<u8>,
+        buf_len: libc::size_t,
     ) -> sallyport::Result {
-        self.trace("get_att", 0);
-        Ok([0.into(), SEV_TECH.into()])
+        self.trace("get_attestation", 4);
+
+        let secret = SEV_SECRET.read();
+
+        match secret.try_len() {
+            Some(mut result_len) => {
+                if buf_len != 0 {
+                    result_len = result_len.min(buf_len);
+                    let buf = buf.validate_slice(buf_len, self).ok_or(libc::EFAULT)?;
+
+                    buf[..result_len].copy_from_slice(
+                        &(SEV_SECRET.read()).try_as_slice().unwrap()[..result_len],
+                    );
+                }
+
+                Ok([result_len.into(), SEV_TECH.into()])
+            }
+            None => Err(libc::ENOSYS),
+        }
     }
 
     fn exit(&mut self, status: i32) -> ! {

--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod builder;
-mod shim;
+pub mod shim;
 mod vm;
 
 pub const SHIM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/bin/shim-sev"));

--- a/src/backend/kvm/vm/builder.rs
+++ b/src/backend/kvm/vm/builder.rs
@@ -53,7 +53,12 @@ pub trait Hook {
         Ok(())
     }
 
-    fn code_loaded(&mut self, _vm: &mut VmFd, _addr_space: &[u8]) -> Result<()> {
+    fn code_loaded(
+        &mut self,
+        _vm: &mut VmFd,
+        _saddr_space: &[u8],
+        _syscall_blocks: VirtAddr,
+    ) -> Result<()> {
         Ok(())
     }
 
@@ -101,7 +106,7 @@ impl<T: Hook> Builder<T> {
 
         let code_offset = boot_info.code.start;
         Self::load_component(addr, &mut self.code, code_offset);
-        self.hook.code_loaded(&mut fd, &map)?;
+        self.hook.code_loaded(&mut fd, &map, arch.syscall_blocks)?;
 
         let vm = Vm {
             kvm,


### PR DESCRIPTION
Inject the secret and provide it with the get_attestation call.

Fixes: https://github.com/enarx/enarx-keepldr/issues/159
