### PR TITLE
fix(lint): Turn on all features with clippy lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: ${{ matrix.crate.target }} --manifest-path=${{ matrix.crate.path }} -- -D warnings
+          args: ${{ matrix.crate.target }} --all-features --manifest-path=${{ matrix.crate.path }} -- -D warnings
     strategy:
       fail-fast: false
       matrix:

--- a/src/backend/sgx/attestation.rs
+++ b/src/backend/sgx/attestation.rs
@@ -24,13 +24,13 @@ pub fn get_attestation(
         let b: &mut [u8] = unsafe { from_raw_parts_mut(buf as *mut u8, buf_len) };
 
         if b.len() != TMP_TI.len() {
-            return Err(Error::new(
+            Err(Error::new(
                 ErrorKind::InvalidData,
                 "Unable to copy TargetInfo to buffer",
-            ));
+            ))
         } else {
             b.copy_from_slice(&TMP_TI);
-            return Ok(TI_SIZE);
+            Ok(TI_SIZE)
         }
 
     // If the nonce in not 0, fills the Quote obtained from the AESMD for the report
@@ -42,13 +42,13 @@ pub fn get_attestation(
         let b: &mut [u8] = unsafe { from_raw_parts_mut(buf as *mut u8, buf_len) };
 
         if b.len() != TMP_QUOTE.len() {
-            return Err(Error::new(
+            Err(Error::new(
                 ErrorKind::InvalidData,
                 "Unable to copy Quote to buffer",
-            ));
+            ))
         } else {
             b.copy_from_slice(&TMP_QUOTE);
-            return Ok(QUOTE_SIZE);
+            Ok(QUOTE_SIZE)
         }
     }
 }


### PR DESCRIPTION
Without `--all-features` not all modules are checked. Namely the `sgx`
backend was completely left out.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
