### PR TITLE
ci(clippy): Check clippy for single backends

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,6 +66,37 @@ jobs:
             path: internal/shim-sev/Cargo.toml
             target: --target=x86_64-unknown-linux-musl
 
+  clippy-single-backends:
+    name: cargo clippy (enarx-keepldr ${{ matrix.backend.name }} ${{ matrix.profile.name }})
+    runs-on: ubuntu-20.04
+    steps:
+      - run: sudo apt update
+      - run: sudo apt install -y musl-tools
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: clippy
+          toolchain: nightly
+          profile: minimal
+          target: x86_64-unknown-linux-musl
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: ${{ matrix.profile.flag }} --no-default-features --features=backend-${{ matrix.backend.name }} -- -D warnings
+    strategy:
+      fail-fast: false
+      matrix:
+        backend:
+          - {name: sev, host: [self-hosted, linux, sev]}
+          - {name: sgx, host: [self-hosted, linux, sgx]}
+          - {name: kvm, host: [self-hosted, linux]}
+          - {name: nil, host: ubuntu-20.04}
+        profile:
+          - name: debug
+          - name: release
+            flag: --release
+
   readme:
     name: cargo readme
     runs-on: ubuntu-latest

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -58,6 +58,8 @@ pub trait Thread {
 }
 
 pub enum Command<'a> {
+    #[allow(dead_code)]
     SysCall(&'a mut Block),
+    #[allow(dead_code)]
     Continue,
 }

--- a/src/binary/component.rs
+++ b/src/binary/component.rs
@@ -81,6 +81,7 @@ impl Component {
     }
 
     /// Find the total memory region for the binary.
+    #[allow(dead_code)]
     pub fn region(&self) -> Line<usize> {
         self.segments
             .iter()

--- a/src/sallyport/mod.rs
+++ b/src/sallyport/mod.rs
@@ -191,6 +191,7 @@ impl Block {
     }
 
     /// Returns a Cursor for the Block
+    #[allow(dead_code)]
     pub fn cursor(&mut self) -> Cursor {
         Cursor(&mut self.buf)
     }


### PR DESCRIPTION
Clippy check also individual backends with the other features disabled.
    
The uncovered clippy failures are also fixed in this PR.
