### PR TITLE
feat(syscall): Collect all syscall constants

### DIFF
--- a/internal/shim-sev/src/hostcall.rs
+++ b/internal/shim-sev/src/hostcall.rs
@@ -4,13 +4,14 @@
 
 use crate::addr::{HostVirtAddr, ShimPhysUnencryptedAddr};
 use crate::asm::_enarx_asm_triple_fault;
-use crate::hostlib::{MemInfo, SYSCALL_TRIGGER_PORT, SYS_ENARX_BALLOON_MEMORY, SYS_ENARX_MEM_INFO};
+use crate::hostlib::{MemInfo, SYSCALL_TRIGGER_PORT};
 use crate::lazy::Lazy;
 use crate::SHIM_HOSTCALL_VIRT_ADDR;
 use core::convert::TryFrom;
 use primordial::{Address, Register};
 use sallyport::{request, Block};
 use spinning::Mutex;
+use syscall::{SYS_ENARX_BALLOON_MEMORY, SYS_ENARX_MEM_INFO};
 use x86_64::instructions::port::Port;
 
 /// Host file descriptor

--- a/internal/shim-sev/src/hostlib.rs
+++ b/internal/shim-sev/src/hostlib.rs
@@ -43,12 +43,6 @@ use primordial::Page;
 #[allow(clippy::integer_arithmetic)]
 pub const ALIGN_ABOVE_2MB: usize = bytes!(2; MiB);
 
-/// Enarx syscall extension: get `MemInfo` from the host
-pub const SYS_ENARX_MEM_INFO: i64 = 33333;
-
-/// Enarx syscall extension: request an additional memory region
-pub const SYS_ENARX_BALLOON_MEMORY: i64 = 33334;
-
 #[inline(always)]
 #[allow(clippy::integer_arithmetic)]
 const fn lower(value: usize, boundary: usize) -> usize {

--- a/internal/shim-sgx/src/event.rs
+++ b/internal/shim-sgx/src/event.rs
@@ -5,13 +5,12 @@ use sgx::types::ssa::{Exception, StateSaveArea};
 
 use crate::handler::{Context, Handler};
 use crate::Layout;
-use syscall::SyscallHandler;
+use syscall::{SyscallHandler, SYS_ENARX_ERESUME};
 
 // Opcode constants, details in Volume 2 of the Intel 64 and IA-32 Architectures Software
 // Developer's Manual
 const OP_SYSCALL: &[u8] = &[0x0f, 0x05];
 const OP_CPUID: &[u8] = &[0x0f, 0xa2];
-const SYS_ERESUME: usize = !0;
 
 #[no_mangle]
 pub extern "C" fn event(
@@ -70,5 +69,5 @@ pub extern "C" fn event(
         }
     }
 
-    block.msg.req.num = SYS_ERESUME.into();
+    block.msg.req.num = SYS_ENARX_ERESUME.into();
 }

--- a/internal/shim-sgx/src/hostlib.rs
+++ b/internal/shim-sgx/src/hostlib.rs
@@ -4,9 +4,6 @@
 
 use lset::Line;
 
-pub const SYS_ERESUME: usize = !0;
-pub const SYS_CPUID: usize = SYS_ERESUME - 1;
-
 /// The enclave layout
 #[repr(C)]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]

--- a/internal/shim-sgx/src/start.S
+++ b/internal/shim-sgx/src/start.S
@@ -9,6 +9,9 @@
 #define STACK   (9 * 8)
 #define SHIM    (10 * 8)
 
+// Keep in sync with syscall::SYS_ENARX_ERESUME
+#define SYS_ENARX_ERESUME (~0)
+
 # Clear all preserved (callee-saved) registers (except %rsp)
 .macro  zerop
     xor     %rbx,                   %rbx
@@ -182,7 +185,7 @@ _start:
     zeroa                                           # Clear argument registers
     zerof   %r11                                    # Clear CPU flags
     zerox                                           # Clear xCPU state
-    mov     $~0,                    %r11            # Indicate ERESUME to VDSO handler
+    mov     $SYS_ENARX_ERESUME,     %r11            # Indicate ERESUME to VDSO handler
 
     # ENCLU[EEXIT]
 .Leexit:

--- a/internal/syscall/src/lib.rs
+++ b/internal/syscall/src/lib.rs
@@ -12,20 +12,7 @@ use primordial::Register;
 use sallyport::{request, Block, Cursor, Request, Result};
 use untrusted::{AddressValidator, UntrustedRef, UntrustedRefMut, Validate, ValidateSlice};
 
-/// `get_attestation` syscall number
-///
-/// See https://github.com/enarx/enarx-keepldr/issues/31
-pub const SYS_GETATT: i64 = 0xEA01;
-
-/// `get_attestation` technology return value
-///
-/// See https://github.com/enarx/enarx-keepldr/issues/31
-pub const SEV_TECH: usize = 1;
-
-/// `get_attestation` technology return value
-///
-/// See https://github.com/enarx/enarx-keepldr/issues/31
-pub const SGX_TECH: usize = 2;
+include!("../../../src/syscall/mod.rs");
 
 // arch_prctl syscalls not available in the libc crate as of version 0.2.69
 /// missing in libc
@@ -175,7 +162,7 @@ pub trait SyscallHandler: AddressValidator + Sized {
             libc::SYS_getegid => self.getegid(),
             libc::SYS_close => self.close(a.try_into().map_err(|_| libc::EINVAL)?),
 
-            SYS_GETATT => self.get_attestation(a.into(), b.into(), c.into(), d.into()),
+            SYS_ENARX_GETATT => self.get_attestation(a.into(), b.into(), c.into(), d.into()),
 
             _ => Err(libc::ENOSYS),
         };

--- a/src/backend/kvm/vm/cpu.rs
+++ b/src/backend/kvm/vm/cpu.rs
@@ -2,11 +2,10 @@
 
 use super::{KvmSegment, Vm};
 
-use crate::backend::kvm::shim::{
-    MemInfo, SYSCALL_TRIGGER_PORT, SYS_ENARX_BALLOON_MEMORY, SYS_ENARX_MEM_INFO,
-};
+use crate::backend::kvm::shim::{MemInfo, SYSCALL_TRIGGER_PORT};
 use crate::backend::{Command, Thread};
 use crate::sallyport::{Block, Reply};
+use crate::syscall::{SYS_ENARX_BALLOON_MEMORY, SYS_ENARX_MEM_INFO};
 
 use anyhow::{anyhow, Result};
 use kvm_ioctls::{VcpuExit, VcpuFd};

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,7 @@
 mod backend;
 mod binary;
 mod sallyport;
+mod syscall;
 
 // workaround for sallyport tests, until we have internal crates
 pub use sallyport::Request;

--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/// `get_attestation` syscall number
+///
+/// See https://github.com/enarx/enarx-keepldr/issues/31
+#[allow(dead_code)]
+pub const SYS_ENARX_GETATT: i64 = 0xEA01;
+
+/// Enarx syscall extension: get `MemInfo` from the host
+#[allow(dead_code)]
+pub const SYS_ENARX_MEM_INFO: i64 = 0xEA02;
+
+/// Enarx syscall extension: request an additional memory region
+#[allow(dead_code)]
+pub const SYS_ENARX_BALLOON_MEMORY: i64 = 0xEA03;
+
+/// Enarx syscall extension: CPUID
+#[allow(dead_code)]
+pub const SYS_ENARX_CPUID: i64 = 0xEA04;
+
+/// Enarx syscall extension: Resume an enclave after an asynchronous exit
+// Keep in sync with shim-sgx/src/start.S
+#[allow(dead_code)]
+pub const SYS_ENARX_ERESUME: i64 = -1;
+
+/// `get_attestation` technology return value
+///
+/// See https://github.com/enarx/enarx-keepldr/issues/31
+#[allow(dead_code)]
+pub const SEV_TECH: usize = 1;
+
+/// `get_attestation` technology return value
+///
+/// See https://github.com/enarx/enarx-keepldr/issues/31
+#[allow(dead_code)]
+pub const SGX_TECH: usize = 2;


### PR DESCRIPTION
The syscall constants are spread all over the place and named
inconsistently. This patch fixes that.
