### PR TITLE
Implement AMD SEV Remote Attestation + builtin synthetic client implementation for unattested launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "atty"
@@ -76,14 +76,20 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
  "arrayvec",
  "constant_time_eq",
 ]
+
+[[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
@@ -205,6 +211,7 @@ dependencies = [
  "codicon",
  "colorful",
  "goblin",
+ "koine",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
@@ -215,6 +222,8 @@ dependencies = [
  "process_control",
  "protobuf",
  "protobuf-codegen-pure",
+ "serde",
+ "serde_cbor",
  "serial_test",
  "sev",
  "sgx",
@@ -222,6 +231,12 @@ dependencies = [
  "walkdir",
  "x86_64",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -261,6 +276,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +304,17 @@ name = "iocuddle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8972d5be69940353d5347a1344cb375d9b457d6809b428b05bb1ca2fb9ce007"
+
+[[package]]
+name = "koine"
+version = "0.1.0"
+source = "git+https://github.com/enarx/koine#040ad4a740c0082b6905593696f9c9bea2918f47"
+dependencies = [
+ "serde",
+ "serde_cbor",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "kvm-bindings"
@@ -407,16 +439,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.18"
+name = "pin-project-lite"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
+checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "primordial"
@@ -503,6 +547,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,18 +633,48 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scroll"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb2332cb595d33f7edd5700f4cbf94892e680c7f0ae56adab58a35190b66cb1"
+checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e367622f934864ffa1c704ba2b82280aab856e3d8213c84c5720257eb34b15b9"
+checksum = "b12bd20b94c7cdfda8c7ba9b92ad0d9a56e3fa018c25fca83b51aa664c9b4c0d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -591,7 +706,7 @@ dependencies = [
 [[package]]
 name = "sev"
 version = "0.1.0"
-source = "git+https://github.com/enarx/sev#66248f21ecd37052454a4c4a5897f5f07cfb77fa"
+source = "git+https://github.com/enarx/sev#3f90139bec3e69c0360d7bb4e4f5e989c19d32aa"
 dependencies = [
  "bitfield",
  "bitflags",
@@ -599,6 +714,7 @@ dependencies = [
  "dirs",
  "iocuddle",
  "openssl",
+ "serde",
 ]
 
 [[package]]
@@ -620,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "strsim"
@@ -675,10 +791,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.6.0"
+name = "tokio"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
+dependencies = [
+ "bytes",
+ "fnv",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
 
 [[package]]
 name = "unicode-width"
@@ -691,6 +830,16 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand",
+ "serde",
+]
 
 [[package]]
 name = "vcpkg"
@@ -722,9 +871,9 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183d25b56a61a6f518ef464ac578e790f04added34dfaab59a453d8a03cb7bd0"
+checksum = "d1cdd1d72e262bbfb014de65ada24c1ac50e10a2e3b1e8ec052df188c2ee5dfa"
 dependencies = [
  "bitflags",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,13 @@ default = ["backend-sev"]
 
 backend-nil = []
 backend-kvm = ["x86_64", "kvm-bindings", "kvm-ioctls"]
-backend-sev = ["sev", "backend-kvm"]
+backend-sev = ["sev", "backend-kvm", "koine"]
 backend-sgx = ["sgx"]
 
 [dependencies]
 sev = { git = "https://github.com/enarx/sev", features = ["openssl"], optional = true }
 sgx = { git = "https://github.com/enarx/sgx", rev = "5292e53", features = ["asm", "crypto"], optional = true }
+koine = { git = "https://github.com/enarx/koine", optional = true }
 x86_64 = { version = "0.11", default-features = false, features = ["stable"], optional = true }
 kvm-bindings = { version = "0.3", optional = true }
 kvm-ioctls = { version = "0.5", optional = true }
@@ -47,6 +48,8 @@ goblin = "0.2"
 libc = "0.2"
 lset = "0.1"
 protobuf = "2.18"
+serde = "1.0"
+serde_cbor = "0.11"
 
 [build-dependencies]
 cc = "1.0"

--- a/src/backend/sev/unattested_launch.rs
+++ b/src/backend/sev/unattested_launch.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! The `unattested_launch` is an implementation of a so-called "synthetic"
+//! or "fake" client that speaks the remote AMD SEV launch protocol. This
+//! exists for several reasons:
+//!
+//!   1.) There is no special-casing in the SEV backend launch process. It
+//!       will speak the same protocol for all launch use-cases. The
+//!       synthetic client allows us to avoid special-casing any of the launch
+//!       code.
+//!   2.) The synthetic client allows for keeps to be launched in solitary
+//!       environments such as CI or other testing where there are no actual
+//!       clients who will participate in the launch protocol.
+//!   3.) Sometimes you just want a keep and you don't care to attest.
+//!   4.) The synthetic client, as a side-effect, also acts as some degree
+//!       of test coverage for the client-side of the remote attestation
+//!       protocol.
+
+use std::convert::TryFrom;
+use std::os::unix::net::UnixStream;
+
+use ::sev::certs::{ca, sev};
+use ::sev::launch::Policy;
+use ::sev::session::Session;
+use codicon::{Decoder, Encoder};
+use koine::attestation::sev::*;
+use serde::de::Deserialize;
+use serde_cbor as serde_flavor;
+
+pub fn launch(sock: UnixStream) {
+    let mut de = serde_flavor::Deserializer::from_reader(&sock);
+    let chain_packet =
+        Message::deserialize(&mut de).expect("failed to deserialize expected certificate chain");
+    let chain_packet = match chain_packet {
+        Message::CertificateChainNaples(chain) => chain,
+        Message::CertificateChainRome(chain) => chain,
+        _ => panic!("expected certificate chain"),
+    };
+
+    let chain = ::sev::certs::Chain {
+        ca: ca::Chain {
+            ark: ca::Certificate::decode(chain_packet.ark.as_slice(), ()).expect("ark"),
+            ask: ca::Certificate::decode(chain_packet.ask.as_slice(), ()).expect("ask"),
+        },
+        sev: sev::Chain {
+            pdh: sev::Certificate::decode(chain_packet.pdh.as_slice(), ()).expect("pdh"),
+            pek: sev::Certificate::decode(chain_packet.pek.as_slice(), ()).expect("pek"),
+            cek: sev::Certificate::decode(chain_packet.cek.as_slice(), ()).expect("cek"),
+            oca: sev::Certificate::decode(chain_packet.oca.as_slice(), ()).expect("oca"),
+        },
+    };
+
+    let policy = Policy::default();
+    let session = Session::try_from(policy).expect("failed to craft policy");
+
+    let start = session.start(chain).expect("failed to start session");
+    let mut ls = LaunchStart {
+        policy: vec![],
+        cert: vec![],
+        session: vec![],
+    };
+    serde_flavor::to_writer(&mut ls.policy, &start.policy).expect("failed to serialize policy");
+    start
+        .cert
+        .encode(&mut ls.cert, ())
+        .expect("start cert encode");
+    serde_flavor::to_writer(&mut ls.session, &start.session).expect("failed to serialize session");
+
+    let start_packet = Message::LaunchStart(ls);
+    serde_flavor::to_writer(&sock, &start_packet).expect("failed to serialize launch start");
+
+    // Discard the measurement, the synthetic client doesn't care
+    // for an unattested launch.
+    let msr =
+        Message::deserialize(&mut de).expect("failed to deserialize expected measurement packet");
+    assert!(matches!(msr, Message::Measurement(_)));
+
+    let secret_packet = Message::Secret(vec![]);
+    serde_flavor::to_writer(&sock, &secret_packet).expect("failed to serialize secret packet");
+
+    let fin = Message::deserialize(&mut de).expect("failed to deserialize expected finish packet");
+    assert!(matches!(fin, Message::Finish(_)));
+}


### PR DESCRIPTION
- Bump sev to 66248f21
- Implement remote AMD SEV attestation protocol

Depends on: https://github.com/enarx/sev/pull/33 before I can unmark this as a draft as the `Cargo.toml` points at my personal `sev` repo.

Helpful for understanding the protocol: https://github.com/enarx/enarx-keepldr/wiki/AMD-SEV-Remote-Attestation-Protocol