### PR TITLE
Fix spurious failure in sgx_get_att_quote test if not running on SGX

### DIFF
--- a/tests/bin/enarx.h
+++ b/tests/bin/enarx.h
@@ -1,0 +1,11 @@
+#ifndef ENARX_H_
+#define ENARX_H_
+
+enum tee_tech {
+    TEE_NONE,
+    TEE_SEV,
+    TEE_SGX,
+};
+
+#endif
+

--- a/tests/bin/get_att.c
+++ b/tests/bin/get_att.c
@@ -1,11 +1,6 @@
 #include "libc.h"
+#include "enarx.h"
 #include <errno.h>
-
-typedef enum {
-    NO_KEEP,
-    SEV,
-    SGX,
-} tech;
 
 int main(void) {
     // TODO: Good buffer length?
@@ -17,9 +12,9 @@ int main(void) {
 
     if (size >= 0) {
 	switch (technology) {
-	case NO_KEEP:
-	case SEV:
-	case SGX:
+	case TEE_NONE:
+	case TEE_SEV:
+	case TEE_SGX:
 	    return 0;
 	default: return 1;
 	}

--- a/tests/bin/sgx_get_att_quote.c
+++ b/tests/bin/sgx_get_att_quote.c
@@ -1,4 +1,5 @@
 #include "libc.h"
+#include "enarx.h"
 #include <errno.h>
 
 /* This test will be run only for SGX. It is designed to request a
@@ -18,7 +19,11 @@ int main(void) {
 
     ssize_t size = get_att(nonce, sizeof(nonce), buf, sizeof(buf), &technology);
 
-    if ((size < 0) || (technology != 2))
+    /* this test is SGX-specific, so just return success if not running on SGX */
+    if (technology != TEE_SGX)
+        return 0;
+
+    if (size < 0)
         return 1;
 
     for (i = 0; i < 3; i++) {


### PR DESCRIPTION
- Factor out TEE enum to its own header
- Return success if not running on SGX in sgx_get_att_quote test
