### PR TITLE
Remove deprecated command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,15 +15,12 @@ jobs:
           target: x86_64-unknown-linux-musl
           toolchain: nightly
           override: true
-      - name: "SEV: Configure environment"
-        if: ${{ matrix.backend.name == 'sev' }}
-        run: echo "::set-env name=SEV_CHAIN::${{ env.HOME }}/.cache/amd-sev/chain"
       - name: "SEV: Cache certificate chain"
         if: ${{ matrix.backend.name == 'sev' }}
         run: |
           cargo install --locked --git https://github.com/enarx/sevctl --rev ac264b44 sevctl
-          mkdir -p `dirname ${{ env.SEV_CHAIN }}`
-          sevctl export --full ${{ env.SEV_CHAIN }}
+          mkdir -p ~/.cache/amd-sev
+          sevctl export --full ~/.cache/amd-sev/chain
       - uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
GitHub Actions will vacuously fail a CI job that uses this command. Just for now. [I am working on removing the affected step entirely](https://github.com/enarx/packet.com/pull/23).

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>

Closes: https://github.com/enarx/enarx-keepldr/issues/83