### PR TITLE
fix build on nightly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,14 +27,12 @@ fn find_files_with_extensions<'a>(
         .map(|x| x.path().to_owned())
 }
 
-fn rerun_src(path: impl AsRef<Path>) -> std::io::Result<()> {
+fn rerun_src(path: impl AsRef<Path>) {
     for entry in find_files_with_extensions(&["rs", "s", "S"], &path) {
         if let Some(path) = entry.to_str() {
             println!("cargo:rerun-if-changed={}", path)
         }
     }
-
-    Ok(())
 }
 
 fn build_rs_tests(in_path: &Path, out_path: &Path) {
@@ -196,7 +194,7 @@ fn main() {
         println!("cargo:rerun-if-changed={}/Cargo.lock", path);
         println!("cargo:rerun-if-changed={}/.cargo/config", path);
 
-        rerun_src(&path).unwrap();
+        rerun_src(&path);
 
         if !shim_name.starts_with("shim-") {
             continue;

--- a/internal/shim-sev/src/payload.rs
+++ b/internal/shim-sev/src/payload.rs
@@ -136,7 +136,7 @@ fn crt0setup(
     app_virt_start: VirtAddr,
     stack_slice: &'static mut [u8],
     header: &Header,
-) -> Result<(VirtAddr, u64), ()> {
+) -> (VirtAddr, u64) {
     let mut builder = Builder::new(stack_slice);
     builder.push("/init").unwrap();
     let mut builder = builder.done().unwrap();
@@ -175,7 +175,7 @@ fn crt0setup(
     let handle = builder.done().unwrap();
     let sp = &*handle as *const _ as u64;
 
-    Ok((ph_entry, sp))
+    (ph_entry, sp)
 }
 
 /// execute the payload
@@ -188,8 +188,7 @@ pub fn execute_payload() -> ! {
         PageTableFlags::USER_ACCESSIBLE,
     );
 
-    let (entry, sp_handle) =
-        crt0setup(*PAYLOAD_VIRT_ADDR.read(), stack.slice, header).expect("crt0setup failed");
+    let (entry, sp_handle) = crt0setup(*PAYLOAD_VIRT_ADDR.read(), stack.slice, header);
 
     unsafe {
         usermode(entry.as_u64(), sp_handle);

--- a/internal/shim-sev/src/usermode.rs
+++ b/internal/shim-sev/src/usermode.rs
@@ -11,7 +11,6 @@ use x86_64::registers::rflags::RFlags;
 ///
 /// Because the caller can give any `entry_point` and `stack_pointer`
 /// including 0, this function is unsafe.
-#[naked]
 pub unsafe fn usermode(ip: u64, sp: u64) -> ! {
     asm!("
         push     {USER_DATA_SEGMENT}

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,7 @@ enum Options {
     Exec(Exec),
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn main() -> Result<()> {
     let backends: &[Box<dyn Backend>] = &[
         #[cfg(feature = "backend-sev")]
@@ -138,6 +139,7 @@ fn main() -> Result<()> {
     }
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn info(backends: &[Box<dyn Backend>]) -> Result<()> {
     use colorful::*;
 
@@ -170,6 +172,7 @@ fn info(backends: &[Box<dyn Backend>]) -> Result<()> {
 }
 
 #[allow(unreachable_code)]
+#[allow(clippy::unnecessary_wraps)]
 fn exec(backends: &[Box<dyn Backend>], opts: Exec) -> Result<()> {
     let keep = std::env::var_os("ENARX_BACKEND").map(|x| x.into_string().unwrap());
 


### PR DESCRIPTION
*   fix(keepldr): suppress clippy warnings
    
    Suppress clippy warnings about `Result<()>`, where the functions never
    return an `Err()` for now.

*   fix(shim-sev): Function crt0setup does not need Result as return
    
    `crt0setup()` never returns an `Err()`, so remove `Result` from the
    return parameter, otherwise clippy will complain.

*   fix(build): Remove unnecessary return value
    
    `rerun_src()` doesn't need a return value, so remove it, because clippy
    will complain.
    
*   fix(shim-sev): remove `naked` attribute from usermode fn
    
    The `#[naked]` caused a rustc segfault. Remove it, because it was the
    wrong attribute anyway.
