### PR TITLE
fix(sallyport): mark copy_into_slice unsafe

### DIFF
--- a/internal/shim-sgx/src/handler.rs
+++ b/internal/shim-sgx/src/handler.rs
@@ -397,8 +397,10 @@ impl<'a> SyscallHandler for Handler<'a> {
         let mut ti = [0u8; 512];
         let ti_len = ti.len();
         let c = self.new_cursor();
-        c.copy_into_slice(buf_len, ti.as_mut(), ti_len)
-            .or(Err(libc::EFAULT))?;
+        unsafe {
+            c.copy_into_slice(buf_len, &mut ti[..ti_len])
+                .or(Err(libc::EFAULT))?;
+        }
         // ... Code to generate Report goes here ...
 
         // Request Quote from host
@@ -419,8 +421,10 @@ impl<'a> SyscallHandler for Handler<'a> {
             self.attacked()
         }
 
-        c.copy_into_slice(buf_len, buf.as_mut(), result_len)
-            .or(Err(libc::EFAULT))?;
+        unsafe {
+            c.copy_into_slice(buf_len, &mut buf[..result_len])
+                .or(Err(libc::EFAULT))?;
+        }
 
         let rep: sallyport::Reply = Ok([result[0], SGX_TECH.into()]).into();
         sallyport::Result::from(rep)

--- a/internal/syscall/src/lib.rs
+++ b/internal/syscall/src/lib.rs
@@ -201,8 +201,10 @@ pub trait SyscallHandler: AddressValidator + Sized {
         }
 
         let c = self.new_cursor();
-        c.copy_into_slice(count, buf[..count].as_mut(), result_len)
-            .or(Err(libc::EFAULT))?;
+        unsafe {
+            c.copy_into_slice(count, &mut buf[..result_len].as_mut())
+                .or(Err(libc::EFAULT))?;
+        }
 
         Ok(ret)
     }
@@ -590,8 +592,10 @@ pub trait SyscallHandler: AddressValidator + Sized {
 
         let c = self.new_cursor();
 
-        c.copy_into_slice(nfds as _, fds, nfds as _)
-            .or(Err(libc::EMSGSIZE))?;
+        unsafe {
+            c.copy_into_slice(nfds as _, &mut fds[..(nfds as usize)])
+                .or(Err(libc::EMSGSIZE))?;
+        }
 
         Ok(result)
     }


### PR DESCRIPTION
*   fix(sallyport): mark copy_into_slice unsafe
    
    `Cursor::copy_into_slice` has to be unsafe, otherwise it is possible to
    fill in a slice of e.g. bools with invalid values using safe rust code.
    
    This patch also adds a test calling `Cursor::copy_into_slice()` and
    simplifies the method by removing a parameter and calling existing
    methods.

