### PR TITLE
Sev concurrent syscalls

### DIFF
--- a/internal/shim-sev/src/asm.rs
+++ b/internal/shim-sev/src/asm.rs
@@ -3,13 +3,13 @@
 //! Functions needing `asm!` blocks
 
 use crate::addr::SHIM_VIRT_OFFSET;
-use crate::hostlib::ALIGN_ABOVE_2MB;
+use crate::hostlib::MAX_SETUP_SIZE;
 use core::mem::size_of;
 use x86_64::instructions::tables::lidt;
 use x86_64::structures::DescriptorTablePointer;
 
 #[allow(clippy::integer_arithmetic)]
-const SHIM_OFFSET: u64 = 1u64 + SHIM_VIRT_OFFSET + ALIGN_ABOVE_2MB as u64;
+const SHIM_OFFSET: u64 = 1u64 + SHIM_VIRT_OFFSET + MAX_SETUP_SIZE as u64;
 
 /// Provoke a triple fault to shutdown the machine
 ///

--- a/internal/shim-sev/src/hostcall.rs
+++ b/internal/shim-sev/src/hostcall.rs
@@ -73,7 +73,11 @@ impl<'a> HostCall<'a> {
         // prevent earlier writes from being moved beyond this point
         core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::Release);
 
-        port.write(1);
+        // FIXME: this should be the number of a free Block slot
+        // see https://github.com/enarx/enarx-keepldr/issues/155
+        let block_nr: u16 = 0;
+
+        port.write(block_nr);
 
         // prevent later reads from being moved before this point
         core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::Acquire);

--- a/internal/shim-sev/src/hostlib.rs
+++ b/internal/shim-sev/src/hostlib.rs
@@ -41,7 +41,7 @@ use primordial::Page;
 
 /// The first 2MB are unencrypted shared memory
 #[allow(clippy::integer_arithmetic)]
-pub const ALIGN_ABOVE_2MB: usize = bytes!(2; MiB);
+pub const MAX_SETUP_SIZE: usize = bytes!(2; MiB);
 
 #[inline(always)]
 #[allow(clippy::integer_arithmetic)]
@@ -124,12 +124,13 @@ impl BootInfo {
         code: Span<usize>,
     ) -> Result<Self, NoMemory> {
         debug_assert!(
-            setup.end < ALIGN_ABOVE_2MB,
-            "The setup area has to be smaller than 2MB"
+            setup.end < MAX_SETUP_SIZE,
+            "The setup area has to be smaller than 2MB < {}",
+            setup.end
         );
 
         // The first 2MB are unencrypted shared memory
-        let shim: Line<usize> = above(setup, shim.count, ALIGN_ABOVE_2MB)
+        let shim: Line<usize> = above(setup, shim.count, MAX_SETUP_SIZE)
             .ok_or(NoMemory(()))?
             .into();
 

--- a/internal/shim-sev/src/hostlib.rs
+++ b/internal/shim-sev/src/hostlib.rs
@@ -78,6 +78,8 @@ pub struct BootInfo {
     pub code: Line<usize>,
     /// Memory size
     pub mem_size: usize,
+    /// Number of `sallyport::Block` provided
+    pub nr_syscall_blocks: usize,
 }
 
 /// Basic information about the host memory
@@ -145,6 +147,7 @@ impl BootInfo {
             shim,
             code,
             mem_size,
+            nr_syscall_blocks: 0,
         })
     }
 }

--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -6,7 +6,7 @@ mod vm;
 
 pub const SHIM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/bin/shim-sev"));
 
-pub use vm::{Builder, Config, Hook, Vm};
+pub use vm::{Builder, Hook, Vm};
 
 use crate::backend::{self, Datum, Keep};
 use crate::binary::Component;
@@ -56,7 +56,7 @@ impl backend::Backend for Backend {
     fn build(&self, code: Component, _sock: Option<&Path>) -> Result<Arc<dyn Keep>> {
         let shim = Component::from_bytes(SHIM)?;
 
-        let vm = Builder::new(Config::default(), shim, code, builder::Kvm).build()?;
+        let vm = Builder::new(shim, code, builder::Kvm).build()?;
 
         Ok(Arc::new(RwLock::new(vm)))
     }

--- a/src/backend/kvm/vm/mod.rs
+++ b/src/backend/kvm/vm/mod.rs
@@ -4,12 +4,13 @@ pub mod builder;
 mod cpu;
 mod mem;
 
+use crate::backend::kvm::shim::MAX_SETUP_SIZE;
 use crate::backend::{Keep, Thread};
 
 use cpu::Cpu;
 use mem::Region;
 
-pub use builder::{Builder, Config, Hook};
+pub use builder::{Builder, Hook, SetupRegion, N_SYSCALL_BLOCKS};
 pub use kvm_bindings::kvm_segment as KvmSegment;
 pub use kvm_bindings::kvm_userspace_memory_region as KvmUserspaceMemoryRegion;
 
@@ -81,7 +82,7 @@ impl Keep for RwLock<Vm> {
         vcpu.set_regs(&regs)?;
         vcpu.set_cpuid2(&keep.kvm.get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)?)?;
 
-        let sallyport = VirtAddr::new(keep.syscall_start.as_u64() + (id * Page::size() as u64));
+        let sallyport = VirtAddr::new(keep.syscall_start.as_u64());
         let thread = Cpu::new(vcpu, sallyport, self.clone(), keep.shim_entry, keep.cr3)?;
         Ok(Box::new(thread))
     }

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -3,8 +3,8 @@
 mod builder;
 mod unattested_launch;
 
+use crate::backend::kvm::Builder;
 use crate::backend::kvm::SHIM;
-use crate::backend::kvm::{Builder, Config};
 use crate::backend::probe::x86_64::{CpuId, Vendor};
 use crate::backend::{self, Datum, Keep};
 use crate::binary::Component;
@@ -253,7 +253,7 @@ impl backend::Backend for Backend {
             }
         };
 
-        let vm = Builder::new(Config::default(), shim, code, builder::Sev::new(sock)).build()?;
+        let vm = Builder::new(shim, code, builder::Sev::new(sock)).build()?;
 
         Ok(Arc::new(RwLock::new(vm)))
     }


### PR DESCRIPTION
*   feat(shim-sev): Use multiple sallyport::Block
    
    Because the setup area is limited in memory size, not each thread can
    get its own `sallyport::Block` to communicate with the host.
    
    Therefore a pool of blocks is reserved, which can be dynamically used
    by the shim indicating the actual block via the value passed in the
    IOPort.
    
    A future extension could reserve additional blocks via a enarx specific
    syscall.
    
    This patch also removes the now obsolete `backend::kvm::vm::Builder::Config`.

    Fixes: https://github.com/enarx/enarx-keepldr/issues/156
    
*   fix(shim-sev): rename ALIGN_ABOVE_2MB
    
    Rename `ALIGN_ABOVE_2MB` to `MAX_SETUP_SIZE` to reflect its meaning.
