### PR TITLE
feat(keepldr): Measure the contents of the keep for SEV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "lset",
  "mmarinus",
  "nbytes",
+ "openssl",
  "primordial",
  "process_control",
  "protobuf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ lset = "0.1"
 protobuf = "2.18"
 serde = "1.0"
 serde_cbor = "0.11"
+openssl = "0.10"
 
 [build-dependencies]
 cc = "1.0"

--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -60,4 +60,8 @@ impl backend::Backend for Backend {
 
         Ok(Arc::new(RwLock::new(vm)))
     }
+
+    fn measure(&self, _code: Component) -> Result<()> {
+        unimplemented!()
+    }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -31,6 +31,10 @@ pub trait Backend {
 
     /// Create a keep instance on this backend
     fn build(&self, code: Component, sock: Option<&Path>) -> Result<Arc<dyn Keep>>;
+
+    /// Create a keep instance on this backend, measure the keep
+    /// and output a json record for the specific backend
+    fn measure(&self, code: Component) -> Result<()>;
 }
 
 pub struct Datum {

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -257,4 +257,11 @@ impl backend::Backend for Backend {
 
         Ok(Arc::new(RwLock::new(vm)))
     }
+
+    fn measure(&self, code: Component) -> Result<()> {
+        let shim = Component::from_bytes(SHIM)?;
+        let (_, sock) = UnixStream::pair()?;
+
+        Builder::new(shim, code, builder::Sev::new(sock)).measure()
+    }
 }

--- a/src/backend/sgx/mod.rs
+++ b/src/backend/sgx/mod.rs
@@ -143,6 +143,10 @@ impl crate::backend::Backend for Backend {
         builder.load(&code_segs)?;
         Ok(builder.build()?)
     }
+
+    fn measure(&self, mut _code: Component) -> Result<()> {
+        unimplemented!()
+    }
 }
 
 impl super::Keep for RwLock<Enclave> {


### PR DESCRIPTION
*   feat(keepldr): Measure the contents of the keep for SEV
    
    This patch adds a new command `measure`, which produces a measurement on
    the deployed keep and outputs relevant data as a json record,
    which can be used by clients to validate a keep.
    
    This patch implements the measurement for the SEV backend.
