### PR TITLE
feat(syscall): translate_shim_to_host_addr does not need `self`

### DIFF
--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -178,7 +178,7 @@ impl SyscallHandler for Handler {
         unsafe { _enarx_asm_triple_fault() };
     }
 
-    fn translate_shim_to_host_addr<T>(&self, buf: *const T) -> *const T {
+    fn translate_shim_to_host_addr<T>(buf: *const T) -> usize {
         let buf_address = Address::from(buf);
         let phys_unencrypted = ShimPhysUnencryptedAddr::try_from(buf_address).unwrap();
         Register::<usize>::from(HostVirtAddr::from(phys_unencrypted)).into()

--- a/internal/shim-sgx/src/handler.rs
+++ b/internal/shim-sgx/src/handler.rs
@@ -115,8 +115,8 @@ impl<'a> AddressValidator for Handler<'a> {
 }
 
 impl<'a> SyscallHandler for Handler<'a> {
-    fn translate_shim_to_host_addr<T>(&self, buf: *const T) -> *const T {
-        buf
+    fn translate_shim_to_host_addr<T>(buf: *const T) -> usize {
+        buf as _
     }
 
     fn new_cursor(&mut self) -> Cursor {

--- a/internal/syscall/src/lib.rs
+++ b/internal/syscall/src/lib.rs
@@ -52,7 +52,7 @@ pub trait SyscallHandler: AddressValidator + Sized {
     fn attacked(&mut self) -> !;
 
     /// Translates a shim virtual address to the host virtual address
-    fn translate_shim_to_host_addr<T>(&self, buf: *const T) -> *const T;
+    fn translate_shim_to_host_addr<T>(buf: *const T) -> usize;
 
     /// Returns a new `Cursor` for the sallyport `Block`
     fn new_cursor(&mut self) -> Cursor;
@@ -190,7 +190,7 @@ pub trait SyscallHandler: AddressValidator + Sized {
 
         let (_, hostbuf) = c.alloc::<u8>(count).or(Err(libc::EMSGSIZE))?;
         let hostbuf = hostbuf.as_ptr();
-        let host_virt = self.translate_shim_to_host_addr(hostbuf);
+        let host_virt = Self::translate_shim_to_host_addr(hostbuf);
 
         let ret = unsafe { self.proxy(request!(libc::SYS_read => fd, host_virt, count))? };
 
@@ -240,7 +240,7 @@ pub trait SyscallHandler: AddressValidator + Sized {
         let c = self.new_cursor();
         let (_, buf) = c.copy_from_slice(buf.as_ref()).or(Err(libc::EMSGSIZE))?;
         let buf = buf.as_ptr();
-        let host_virt = self.translate_shim_to_host_addr(buf);
+        let host_virt = Self::translate_shim_to_host_addr(buf);
 
         let ret = unsafe { self.proxy(request!(libc::SYS_write => fd, host_virt, count))? };
 
@@ -422,7 +422,7 @@ pub trait SyscallHandler: AddressValidator + Sized {
 
         let (_, buf) = c.alloc::<libc::timespec>(1).or(Err(libc::EMSGSIZE))?;
         let buf = buf[0].as_ptr();
-        let host_virt = self.translate_shim_to_host_addr(buf);
+        let host_virt = Self::translate_shim_to_host_addr(buf);
 
         let result =
             unsafe { self.proxy(request!(libc::SYS_clock_gettime => clockid, host_virt))? };
@@ -586,7 +586,7 @@ pub trait SyscallHandler: AddressValidator + Sized {
 
         let (_, buf) = c.copy_from_slice(fds).or(Err(libc::EMSGSIZE))?;
         let buf = buf.as_ptr();
-        let host_virt = self.translate_shim_to_host_addr(buf);
+        let host_virt = Self::translate_shim_to_host_addr(buf);
 
         let result = unsafe { self.proxy(request!(libc::SYS_poll => host_virt, nfds, timeout))? };
 


### PR DESCRIPTION
The `SyscallHandler::translate_shim_to_host_addr` previously took `self`
as a parameter. This causes problems, if other methods take a mutable
`self`. To avoid clashes, remove `self` from `translate_shim_to_host_addr`.

Also return `usize`, to prevent usage as a real pointer, because it's
a host virtual address, which is most likely not the same address space
(except for SGX).

Signed-off-by: Harald Hoyer <harald@redhat.com>
