### PR TITLE
fix(shim): naked functions need ABI specifier

### DIFF
--- a/internal/shim-sev/src/start.rs
+++ b/internal/shim-sev/src/start.rs
@@ -27,7 +27,7 @@ static INITIAL_SHIM_STACK: [Page; INITIAL_STACK_PAGES] = [Page::zeroed(); INITIA
 #[allow(clippy::integer_arithmetic)]
 #[no_mangle]
 #[naked]
-pub unsafe fn _start() -> ! {
+pub unsafe extern "sysv64" fn _start() -> ! {
     asm!(
         "
     // Check if we have a valid (0x8000_001F) CPUID leaf

--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -35,7 +35,7 @@ struct X8664DoubleReturn {
 /// This function is not be called from rust.
 #[inline(never)]
 #[naked]
-pub unsafe fn _syscall_enter() -> ! {
+pub unsafe extern "sysv64" fn _syscall_enter() -> ! {
     use crate::gdt::{USER_CODE_SEGMENT, USER_DATA_SEGMENT};
     // TaskStateSegment.privilege_stack_table[0]
     const KERNEL_RSP_OFF: usize = size_of::<u32>();

--- a/internal/shim-sgx/src/enclave.rs
+++ b/internal/shim-sgx/src/enclave.rs
@@ -40,7 +40,7 @@ mod _internal {
     ///  Otherwise, we are handling an exception.
     #[no_mangle]
     #[naked]
-    pub unsafe fn _start() -> ! {
+    pub unsafe extern "sysv64" fn _start() -> ! {
         asm!("
     xchg    rcx,                    rbx             # Swap TCS and next instruction.
     add     rcx,                    4096            # rcx = &Layout


### PR DESCRIPTION
Current nightly does not accept `extern "Rust"` (which is the default)
for naked functions. It really should be `extern "custom"`, but that
does not exist, so choose the well known "sysv64" ABI.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
