### PR TITLE
shim-sev: two fixes for the page tables

### DIFF
--- a/internal/shim-sev/src/addr.rs
+++ b/internal/shim-sev/src/addr.rs
@@ -13,9 +13,9 @@ pub const SHIM_VIRT_OFFSET: u64 = 0xFFFF_FF80_0000_0000;
 #[allow(clippy::integer_arithmetic)]
 pub const BYTES_2_MIB: u64 = bytes![2; MiB];
 
-/// 2 GiB
+/// 1 GiB
 #[allow(clippy::integer_arithmetic)]
-pub const BYTES_2_GIB: u64 = bytes![2; GiB];
+pub const BYTES_1_GIB: u64 = bytes![1; GiB];
 
 use crate::frame_allocator::FRAME_ALLOCATOR;
 use crate::get_cbit_mask;

--- a/internal/shim-sev/src/pagetables.rs
+++ b/internal/shim-sev/src/pagetables.rs
@@ -6,7 +6,7 @@
 //! * PDPT_OFFSET: an offset page table with offset $SHIM_OFFSET
 
 use crate::addr::SHIM_VIRT_OFFSET;
-use crate::addr::{BYTES_2_GIB, BYTES_2_MIB};
+use crate::addr::{BYTES_1_GIB, BYTES_2_MIB};
 use crate::paging;
 use array_const_fn_init::array_const_fn_init;
 use x86_64::instructions::tlb::flush;
@@ -29,9 +29,9 @@ const fn gen_2mb_pdt_entries(i: usize) -> u64 {
 }
 
 #[allow(clippy::integer_arithmetic)]
-const fn gen_2gb_pdpt_entries(i: usize) -> u64 {
+const fn gen_1gb_pdpt_entries(i: usize) -> u64 {
     let base: u64 = HUGE_PAGE_TABLE_FLAGS;
-    let step: u64 = BYTES_2_GIB;
+    let step: u64 = BYTES_1_GIB;
     base + (i as u64) * step
 }
 
@@ -54,7 +54,7 @@ pub static mut PML4T: AlignedPageTable = AlignedPageTable([0; 512]);
 /// CR3 for shim and user space.
 #[no_mangle]
 pub static mut PDPT_OFFSET: AlignedPageTable =
-    AlignedPageTable(array_const_fn_init![gen_2gb_pdpt_entries; 512]);
+    AlignedPageTable(array_const_fn_init![gen_1gb_pdpt_entries; 512]);
 
 /// Offset Page-Directory Table
 #[no_mangle]

--- a/internal/shim-sev/src/start.rs
+++ b/internal/shim-sev/src/start.rs
@@ -114,7 +114,7 @@ SevExit:
     mov     ecx,    512         // Counter to 512 page table entries
     add     rbx,    4           // Pre-advance pointer by 4 bytes for the higher 32bit
 setCBit_PDT_OFFSET:
-    mov     DWORD PTR [rbx],    edx
+    or      DWORD PTR [rbx],edx // set C-bit
     add     rbx,    8           // advance pointer by 8
     loop    setCBit_PDT_OFFSET
 
@@ -124,7 +124,7 @@ setCBit_PDT_OFFSET:
     mov     ecx,    512         // Counter to 512 page table entries
     add     rbx,    4           // Pre-advance pointer by 4 bytes for the higher 32bit
 setCBit_PDPT_OFFSET:
-    mov     DWORD PTR [rbx],    edx
+    or      DWORD PTR [rbx],edx // set C-bit
     add     rbx,    8           // advance pointer by 8
     loop    setCBit_PDPT_OFFSET
 
@@ -140,9 +140,9 @@ setCBit_PDPT_OFFSET:
     // set C-bit for the first 3 entries in the PDT_IDENT table
     lea     rcx,    [rip + PDT_IDENT]
     mov     rdx,    r11
-    mov     DWORD PTR [rcx + (0*8 + 4)],    edx
-    mov     DWORD PTR [rcx + (1*8 + 4)],    edx
-    mov     DWORD PTR [rcx + (2*8 + 4)],    edx
+    or      DWORD PTR [rcx + (0*8 + 4)],    edx
+    or      DWORD PTR [rcx + (1*8 + 4)],    edx
+    or      DWORD PTR [rcx + (2*8 + 4)],    edx
 
     // setup PDPT_IDENT table entry 0 with PDT_IDENT table
     lea     rbx,    [rip + PDPT_IDENT]


### PR DESCRIPTION
While experimenting with the allocator, I found the page tables to be setup incorrectly.

Here are two patches to fix that:

*   fix(shim-sev): Fix page table entries offset page table
    
    The huge pages for the offset page table used 2 GiB steps, instead
    of 1 GiB, which resulted in invalid mappings.

*   fix(shim-sev): Fix C-bit setup in start assembler
    
    The C-bit correction in assembler used `mov` instead
    of `or` to set the C-bit. This cleared existing bits
    and resulted in invalid page table entries.
