### PR TITLE
fix(shim-sev): increase stack size, decrease exception stack size

### DIFF
--- a/internal/shim-sev/src/gdt.rs
+++ b/internal/shim-sev/src/gdt.rs
@@ -21,14 +21,14 @@ pub const SHIM_STACK_START: u64 = 0xFFFF_FF48_4800_0000;
 
 /// The size of the main kernel stack
 #[allow(clippy::integer_arithmetic)]
-pub const SHIM_STACK_SIZE: u64 = bytes![4; MiB];
+pub const SHIM_STACK_SIZE: u64 = bytes![8; MiB];
 
 /// The virtual address of the exception kernel stacks
 pub const SHIM_EX_STACK_START: u64 = 0xFFFF_FF48_F000_0000;
 
 /// The size of the main kernel stack
 #[allow(clippy::integer_arithmetic)]
-pub const SHIM_EX_STACK_SIZE: u64 = bytes![2; MiB];
+pub const SHIM_EX_STACK_SIZE: u64 = bytes![4; KiB];
 
 /// The initial shim stack
 pub static INITIAL_STACK: Lazy<GuardedStack> = Lazy::new(|| {


### PR DESCRIPTION
Increase the `shim-sev` stack size to the size of the default Linux
stack size of 8MB. Decrease the *currently* unused exception stack
size.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
