### PR TITLE
fix(shim-sev): add an addition 32MB to the memory

### DIFF
--- a/internal/shim-sev/src/hostlib.rs
+++ b/internal/shim-sev/src/hostlib.rs
@@ -144,6 +144,7 @@ impl BootInfo {
     ///
     /// `NoMemory`: if there is not enough memory for the shim to operate
     #[inline]
+    #[allow(clippy::integer_arithmetic)]
     pub fn calculate(
         setup: Line<usize>,
         shim: Span<usize>,
@@ -164,7 +165,9 @@ impl BootInfo {
             .ok_or(NoMemory(()))?
             .into();
 
-        let mem_size = raise(code.end, Page::size()).ok_or(NoMemory(()))?;
+        let mut mem_size = raise(code.end, Page::size()).ok_or(NoMemory(()))?;
+        // Initial space for basic memory allocations
+        mem_size = mem_size.checked_add(bytes!(32; MiB)).unwrap();
 
         Ok(Self {
             setup,


### PR DESCRIPTION
Add an additional 32MB to the memory size to accommodate for stacks and
page tables, otherwise the shim has to balloon immediately.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
