### PR TITLE
fix(shim-sev): fix the panic handling of locked objects

### DIFF
--- a/internal/shim-sev/src/main.rs
+++ b/internal/shim-sev/src/main.rs
@@ -185,12 +185,12 @@ unsafe fn stack_trace() {
 
     print::_eprint(format_args!("TRACE:\n"));
 
-    if SHIM_PAGETABLE.is_locked() {
-        SHIM_PAGETABLE.force_unlock_read();
+    if SHIM_PAGETABLE.try_read().is_none() {
+        SHIM_PAGETABLE.force_unlock_write()
     }
 
-    if BOOT_INFO.is_locked() {
-        BOOT_INFO.force_unlock_read();
+    if BOOT_INFO.try_read().is_none() {
+        BOOT_INFO.force_unlock_write();
     }
 
     let bootinfo = BOOT_INFO.read();


### PR DESCRIPTION
`force_unlock_read()` panics, if the RWLock is not locked readable,
which is the case, if it is locked writeable.

Therefore only call `force_unlock_write()`, if a read lock could not be
acquired.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
