### PR TITLE
feat(shim-sev): rename frame_allocator -> allocator

### DIFF
--- a/internal/shim-sev/src/addr.rs
+++ b/internal/shim-sev/src/addr.rs
@@ -17,7 +17,7 @@ pub const BYTES_2_MIB: u64 = bytes![2; MiB];
 #[allow(clippy::integer_arithmetic)]
 pub const BYTES_2_GIB: u64 = bytes![2; GiB];
 
-use crate::frame_allocator::FRAME_ALLOCATOR;
+use crate::allocator::ALLOCATOR;
 use crate::get_cbit_mask;
 use core::convert::TryFrom;
 use nbytes::bytes;
@@ -39,7 +39,7 @@ impl<U> HostVirtAddr<U> {
 impl<U> From<ShimPhysUnencryptedAddr<U>> for HostVirtAddr<U> {
     #[inline(always)]
     fn from(val: ShimPhysUnencryptedAddr<U>) -> Self {
-        FRAME_ALLOCATOR.read().phys_to_host(val)
+        ALLOCATOR.read().phys_to_host(val)
     }
 }
 

--- a/internal/shim-sev/src/main.rs
+++ b/internal/shim-sev/src/main.rs
@@ -19,9 +19,9 @@ extern crate rcrt1;
 pub mod print;
 
 pub mod addr;
+pub mod allocator;
 pub mod asm;
 pub mod attestation;
-pub mod frame_allocator;
 pub mod gdt;
 pub mod hostcall;
 /// Shared components for the shim and the loader

--- a/internal/shim-sev/src/payload.rs
+++ b/internal/shim-sev/src/payload.rs
@@ -2,7 +2,7 @@
 
 //! Functions dealing with the payload
 use crate::addr::{ShimPhysAddr, ShimVirtAddr};
-use crate::frame_allocator::FRAME_ALLOCATOR;
+use crate::allocator::ALLOCATOR;
 use crate::paging::SHIM_PAGETABLE;
 use crate::random::random;
 use crate::shim_stack::init_stack_with_guard;
@@ -114,7 +114,7 @@ fn map_elf(app_virt_start: VirtAddr) -> &'static Header {
 
         debug_assert_eq!(ph.p_align, Page::<Size4KiB>::SIZE);
 
-        FRAME_ALLOCATOR
+        ALLOCATOR
             .write()
             .map_memory(
                 SHIM_PAGETABLE.write().deref_mut(),

--- a/internal/shim-sev/src/shim_stack.rs
+++ b/internal/shim-sev/src/shim_stack.rs
@@ -2,7 +2,7 @@
 
 //! Helper functions for the shim stack
 
-use crate::frame_allocator::FRAME_ALLOCATOR;
+use crate::allocator::ALLOCATOR;
 use crate::paging::SHIM_PAGETABLE;
 use core::ops::DerefMut;
 use x86_64::structures::paging::{Page, PageTableFlags, Size4KiB};
@@ -23,7 +23,7 @@ pub fn init_stack_with_guard(
     extra_flags: PageTableFlags,
 ) -> GuardedStack {
     // guard page
-    FRAME_ALLOCATOR
+    ALLOCATOR
         .write()
         .allocate_and_map_memory(
             SHIM_PAGETABLE.write().deref_mut(),
@@ -34,7 +34,7 @@ pub fn init_stack_with_guard(
         )
         .expect("Stack guard page allocation failed");
 
-    let mem_slice = FRAME_ALLOCATOR
+    let mem_slice = ALLOCATOR
         .write()
         .allocate_and_map_memory(
             SHIM_PAGETABLE.write().deref_mut(),
@@ -52,7 +52,7 @@ pub fn init_stack_with_guard(
         .expect("Stack allocation failed");
 
     // guard page
-    FRAME_ALLOCATOR
+    ALLOCATOR
         .write()
         .allocate_and_map_memory(
             SHIM_PAGETABLE.write().deref_mut(),

--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -3,10 +3,10 @@
 //! syscall interface layer between assembler and rust
 
 use crate::addr::{HostVirtAddr, ShimPhysUnencryptedAddr};
+use crate::allocator::ALLOCATOR;
 use crate::asm::_enarx_asm_triple_fault;
 use crate::attestation::SEV_SECRET;
 use crate::eprintln;
-use crate::frame_allocator::FRAME_ALLOCATOR;
 use crate::hostcall::{self, HostCall, HOST_CALL};
 use crate::paging::SHIM_PAGETABLE;
 use crate::payload::{NEXT_BRK_RWLOCK, NEXT_MMAP_RWLOCK};
@@ -364,7 +364,7 @@ impl SyscallHandler for Handler {
                 let virt_addr = *NEXT_MMAP_RWLOCK.read().deref();
                 let len_aligned = align_up(length as _, Page::<Size4KiB>::SIZE) as _;
 
-                let mem_slice = FRAME_ALLOCATOR
+                let mem_slice = ALLOCATOR
                     .write()
                     .allocate_and_map_memory(
                         SHIM_PAGETABLE.write().deref_mut(),
@@ -433,7 +433,7 @@ impl SyscallHandler for Handler {
                     .checked_sub(next_brk.as_u64() as usize)
                     .ok_or(libc::EINVAL)?;
                 let len_aligned = align_up(len as _, Page::<Size4KiB>::SIZE) as _;
-                let _ = FRAME_ALLOCATOR
+                let _ = ALLOCATOR
                     .write()
                     .allocate_and_map_memory(
                         SHIM_PAGETABLE.write().deref_mut(),


### PR DESCRIPTION
This patch prepares for turning the frame_allocator into
a general purpose allocator.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
