### PR TITLE
Refactor VM builder modules

### DIFF
--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -6,7 +6,7 @@ mod vm;
 
 pub const SHIM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/bin/shim-sev"));
 
-pub use vm::{Builder, Hook, Vm};
+pub use vm::{Builder, Hook, Hv2GpFn, Vm};
 
 use crate::backend::{self, Datum, Keep};
 use crate::binary::Component;

--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -62,13 +62,14 @@ impl backend::Backend for Backend {
         Ok(Arc::new(RwLock::new(vm)))
     }
 
-    fn measure(&self, code: Component) -> Result<()> {
+    fn measure(&self, code: Component) -> Result<String> {
         let shim = Component::from_bytes(SHIM)?;
 
         let digest = Builder::new(shim, code, builder::Kvm)
             .build::<X86>()?
             .measurement(MessageDigest::null())?;
-        println!(r#"{{ "backend": "kvm", "null": {:?} }}"#, digest);
-        Ok(())
+
+        let json = format!(r#"{{ "backend": "kvm", "null": {:?} }}"#, digest);
+        Ok(json)
     }
 }

--- a/src/backend/kvm/mod.rs
+++ b/src/backend/kvm/mod.rs
@@ -6,7 +6,7 @@ mod vm;
 
 pub const SHIM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/bin/shim-sev"));
 
-pub use vm::{Builder, Hook, Hv2GpFn, Vm};
+pub use vm::{Arch, Builder, Hook, Hv2GpFn, Vm, X86};
 
 use crate::backend::{self, Datum, Keep};
 use crate::binary::Component;
@@ -56,7 +56,7 @@ impl backend::Backend for Backend {
     fn build(&self, code: Component, _sock: Option<&Path>) -> Result<Arc<dyn Keep>> {
         let shim = Component::from_bytes(SHIM)?;
 
-        let vm = Builder::new(shim, code, builder::Kvm).build()?;
+        let vm = Builder::new(shim, code, builder::Kvm).build::<X86>()?;
 
         Ok(Arc::new(RwLock::new(vm)))
     }

--- a/src/backend/kvm/vm/builder.rs
+++ b/src/backend/kvm/vm/builder.rs
@@ -10,43 +10,13 @@ use kvm_ioctls::{Kvm, VmFd};
 use lset::{Line, Span};
 use mmarinus::{perms, Kind, Map};
 use nbytes::bytes;
-use primordial::Page;
-use x86_64::structures::paging::page_table::{PageTable, PageTableFlags};
 use x86_64::{align_up, PhysAddr, VirtAddr};
 
-use std::mem::{align_of, size_of};
+use std::mem::size_of;
 
-/// The first part of the setup area of the VM
-///
-/// - The first page is a zero page.
-/// - The page tables follow the zero page.
-#[repr(C, align(4096))]
-pub struct SetupRegionPre {
-    zero_page: Page,
-    pml4t: PageTable,
-    pml3t_ident: PageTable,
+fn num_syscall_blocks<A: image::Arch>() -> usize {
+    (MAX_SETUP_SIZE - size_of::<A>()) / size_of::<Block>()
 }
-
-/// The setup area of the VM
-///
-/// The address space needs to be laid out in a way that the shim
-/// is expecting. This means that:
-/// - The first page is a zero page.
-/// - The page tables follow the zero page.
-/// - The rest of the `MAX_SETUP_SIZE` bytes is consumed by an
-///   array of [`sallyport::Block`](crate::sallyport::Block)
-/// - The first shared [`sallyport::Block`](crate::sallyport::Block)
-///   contains the [`BootInfo`](crate::backend::kvm::shim::BootInfo) struct at start.
-///   The [`BootInfo`](crate::backend::kvm::shim::BootInfo)
-///   struct communicates other important values to the shim.
-#[repr(C, align(4096))]
-pub struct SetupRegion {
-    pre: SetupRegionPre,
-    syscall_blocks: [Block; N_SYSCALL_BLOCKS],
-}
-
-pub const N_SYSCALL_BLOCKS: usize =
-    (MAX_SETUP_SIZE - size_of::<SetupRegionPre>()) / size_of::<Block>();
 
 /// A functor type that receives a target address as its first input,
 /// a base/memory region starting address as its second input, and it
@@ -87,11 +57,6 @@ pub struct Builder<T: Hook> {
     code: Component,
 }
 
-struct Arch {
-    syscall_blocks: VirtAddr,
-    cr3: PhysAddr,
-}
-
 #[allow(dead_code)]
 enum BuildOrMeasure {
     Build,
@@ -103,30 +68,34 @@ impl<T: Hook> Builder<T> {
         Self { shim, code, hook }
     }
 
-    fn build_or_measure(mut self, bor: BuildOrMeasure) -> Result<Option<Vm>> {
+    fn build_or_measure<A: image::Arch>(mut self, bor: BuildOrMeasure) -> Result<Option<Vm<A>>> {
         let kvm = Kvm::new()?;
         let mut fd = kvm.create_vm()?;
 
-        let mut boot_info =
-            Self::calculate_setup_region(self.shim.region().into(), self.code.region().into())?;
+        let mut boot_info = Self::calculate_setup_region::<A>(
+            self.shim.region().into(),
+            self.code.region().into(),
+        )?;
 
         let mem_size = align_up(boot_info.mem_size as _, bytes![2; MiB]);
         // fill out remaining fields of `BootInfo`
-        boot_info.nr_syscall_blocks = N_SYSCALL_BLOCKS;
+        boot_info.nr_syscall_blocks = num_syscall_blocks::<A>();
         boot_info.mem_size = mem_size as _;
+
         let (map, region) = Self::allocate_address_space(mem_size as _)?;
         unsafe { fd.set_user_memory_region(region)? };
 
-        let arch = self.arch_specific_setup(&map, &boot_info);
+        let initial_state = unsafe { &mut *(map.addr() as *mut () as *mut image::Image<A>) };
 
-        let addr = VirtAddr::new(map.addr() as u64);
+        let components = &mut [
+            (&mut self.shim, boot_info.shim.start),
+            (&mut self.code, boot_info.code.start),
+        ];
+        initial_state.commit(&map, &boot_info, &self.hook, components);
+
         let shim_start = boot_info.shim.start;
-        Self::load_component(addr, &mut self.shim, shim_start);
         let shim_entry = PhysAddr::new(self.shim.entry as _);
         self.hook.shim_loaded(&mut fd, &map)?;
-
-        let code_offset = boot_info.code.start;
-        Self::load_component(addr, &mut self.code, code_offset);
 
         match bor {
             BuildOrMeasure::Measure => {
@@ -135,9 +104,12 @@ impl<T: Hook> Builder<T> {
             }
 
             BuildOrMeasure::Build => {
-                self.hook.code_loaded(&mut fd, &map, arch.syscall_blocks)?;
+                self.hook
+                    .code_loaded(&mut fd, &map, initial_state.syscall_region_start())?;
+
+                let arch = VirtAddr::from_ptr(&initial_state.arch as *const A);
                 let syscall_blocks = Span {
-                    start: arch.syscall_blocks,
+                    start: initial_state.syscall_region_start(),
                     count: NonZeroUsize::new(boot_info.nr_syscall_blocks).unwrap(),
                 };
 
@@ -149,7 +121,8 @@ impl<T: Hook> Builder<T> {
                     hv2gp: self.hook.hv2gp(),
                     shim_entry,
                     shim_start: PhysAddr::new(shim_start as _),
-                    cr3: arch.cr3,
+                    arch,
+                    _phantom: PhantomData,
                 };
 
                 Ok(Some(vm))
@@ -157,20 +130,24 @@ impl<T: Hook> Builder<T> {
         }
     }
 
-    pub fn build(self) -> Result<Vm> {
-        self.build_or_measure(BuildOrMeasure::Build)
+    pub fn build<A: image::Arch>(self) -> Result<Vm<A>> {
+        self.build_or_measure::<A>(BuildOrMeasure::Build)
             .map(|o| o.unwrap())
     }
 
     #[allow(dead_code)]
-    pub fn measure(self) -> Result<()> {
-        self.build_or_measure(BuildOrMeasure::Measure).map(|_| ())
+    pub fn measure<A: image::Arch>(self) -> Result<()> {
+        self.build_or_measure::<A>(BuildOrMeasure::Measure)
+            .map(|_| ())
     }
 
-    fn calculate_setup_region(shim_size: Span<usize>, code_size: Span<usize>) -> Result<BootInfo> {
+    fn calculate_setup_region<A: image::Arch>(
+        shim_size: Span<usize>,
+        code_size: Span<usize>,
+    ) -> Result<BootInfo> {
         let setup_size = Line {
             start: 0,
-            end: size_of::<SetupRegion>(),
+            end: size_of::<image::Image<A>>() + num_syscall_blocks::<A>(),
         };
 
         let boot_info = BootInfo::calculate(setup_size, shim_size, code_size)
@@ -198,62 +175,5 @@ impl<T: Hook> Builder<T> {
         let res = (map, region);
 
         Ok(res)
-    }
-
-    fn arch_specific_setup(&mut self, map: &Map<perms::ReadWrite>, boot_info: &BootInfo) -> Arch {
-        use PageTableFlags as Flags;
-
-        // This assumes all the bytes in `map` are initialized with zero, which
-        // is normally the case with MAP_ANONYMOUS
-        debug_assert!(map.size() >= size_of::<SetupRegion>());
-        debug_assert_eq!(map.addr() % align_of::<SetupRegion>(), 0);
-        let setup = unsafe { &mut *(map.addr() as *mut SetupRegion) };
-        let hv2gp = self.hook.hv2gp();
-
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                boot_info,
-                &mut setup.syscall_blocks[0] as *mut Block as _,
-                1,
-            );
-        }
-
-        let pml3t_ident_addr = VirtAddr::new(&setup.pre.pml3t_ident as *const _ as u64);
-        let start = VirtAddr::new(map.addr() as u64);
-        let pdpte = hv2gp(pml3t_ident_addr, start);
-        setup.pre.pml4t[0].set_addr(pdpte, Flags::WRITABLE | Flags::PRESENT);
-
-        let pml3t_addr = hv2gp(start, start);
-        let flags = Flags::HUGE_PAGE | Flags::WRITABLE | Flags::PRESENT;
-        setup.pre.pml3t_ident[0].set_addr(pml3t_addr, flags);
-
-        let pml4t = VirtAddr::new(&setup.pre.pml4t as *const _ as _);
-
-        let cr3 = hv2gp(pml4t, start);
-        let syscall_blocks = VirtAddr::from_ptr(setup.syscall_blocks.as_ptr());
-
-        // The information returned here is used by the KVM VM during runtime
-        // to create vCPUs.
-        Arch {
-            syscall_blocks,
-            cr3,
-        }
-    }
-
-    fn load_component(start: VirtAddr, component: &mut Component, offset: usize) {
-        use std::slice::from_raw_parts_mut;
-
-        if component.pie {
-            component.entry += offset;
-            for seg in &mut component.segments {
-                seg.dst += offset;
-            }
-        }
-
-        for seg in &component.segments {
-            let dst = VirtAddr::new(seg.dst as u64 + start.as_u64());
-            let dst = unsafe { from_raw_parts_mut(dst.as_mut_ptr::<Page>(), seg.src.len()) };
-            dst.copy_from_slice(&seg.src[..]);
-        }
     }
 }

--- a/src/backend/kvm/vm/builder.rs
+++ b/src/backend/kvm/vm/builder.rs
@@ -136,12 +136,16 @@ impl<T: Hook> Builder<T> {
 
             BuildOrMeasure::Build => {
                 self.hook.code_loaded(&mut fd, &map, arch.syscall_blocks)?;
+                let syscall_blocks = Span {
+                    start: arch.syscall_blocks,
+                    count: NonZeroUsize::new(boot_info.nr_syscall_blocks).unwrap(),
+                };
 
                 let vm = Vm {
                     kvm,
                     fd,
                     regions: vec![Region::new(region, map)],
-                    syscall_start: arch.syscall_blocks,
+                    syscall_blocks,
                     hv2gp: self.hook.hv2gp(),
                     shim_entry,
                     shim_start: PhysAddr::new(shim_start as _),

--- a/src/backend/kvm/vm/image/mod.rs
+++ b/src/backend/kvm/vm/image/mod.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Modularized components for creating the initial state of VM-based keeps.
+
+pub mod x86;
+
+use std::mem::{align_of, size_of};
+
+use mmarinus::{perms::ReadWrite, Map};
+use primordial::Page;
+use x86_64::VirtAddr;
+
+use crate::backend::kvm::shim::BootInfo;
+use crate::backend::kvm::Hook;
+use crate::binary::Component;
+use crate::sallyport::Block;
+
+/// The `Arch` trait enables architecture-specific setup for the initial
+/// image.
+///
+/// For example, an X86_64 implementation of this could be a struct
+/// that places and configures page tables.
+pub trait Arch {
+    fn commit(&mut self, backing: &Map<ReadWrite>, hook: &impl Hook);
+}
+
+/// The `Image` struct facilitates the construction of a VM image based
+/// on what architecture it is meant for.
+///
+/// NOTE: This struct is meant to be superimposed over the initial address
+/// space starting at address zero; otherwise the image setup will be wrong.
+/// To do this, cast the beginning address of the `mmap`'d address space into
+/// an `Image` struct.
+#[repr(C, align(4096))]
+pub struct Image<A: Arch> {
+    pub arch: A,
+}
+
+impl<A: Arch> Image<A> {
+    /// Performs setup and commits the image to the address space.
+    ///
+    /// NOTE: this must only be called through a pointer that superimposes
+    /// the `Image` struct over the initial address space.
+    pub fn commit(
+        &mut self,
+        backing: &Map<ReadWrite>,
+        boot_info: &BootInfo,
+        hook: &impl Hook,
+        components: &mut [(&mut Component, usize)],
+    ) {
+        assert_eq!(backing.addr() % align_of::<Self>(), 0);
+        assert!(
+            boot_info.mem_size
+                >= size_of::<Self>() + boot_info.nr_syscall_blocks * size_of::<Block>()
+        );
+
+        self.arch.commit(backing, hook);
+
+        // Install the BootInfo struct to the first shared page.
+        unsafe {
+            let syscall_block = (self as *mut _ as *mut u8).add(size_of::<Self>()) as *mut BootInfo;
+            std::ptr::copy_nonoverlapping(boot_info, syscall_block, 1);
+        }
+
+        // Load the shim and code.
+        for (component, offset) in components {
+            self.load_component(VirtAddr::new(backing.addr() as _), component, *offset);
+        }
+    }
+
+    fn load_component(&mut self, start: VirtAddr, component: &mut Component, offset: usize) {
+        use std::slice::from_raw_parts_mut;
+
+        if component.pie {
+            component.entry += offset;
+            for seg in &mut component.segments {
+                seg.dst += offset;
+            }
+        }
+
+        for seg in &component.segments {
+            let dst = VirtAddr::new(seg.dst as u64 + start.as_u64());
+            let dst = unsafe { from_raw_parts_mut(dst.as_mut_ptr::<Page>(), seg.src.len()) };
+            dst.copy_from_slice(&seg.src[..]);
+        }
+    }
+
+    pub fn syscall_region_start(&self) -> VirtAddr {
+        unsafe { VirtAddr::from_ptr((self as *const Self).add(1)) }
+    }
+}

--- a/src/backend/kvm/vm/image/x86.rs
+++ b/src/backend/kvm/vm/image/x86.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Architecture-specific setup for x86_64 VMs.
+
+use mmarinus::{perms::ReadWrite, Map};
+use primordial::Page;
+use x86_64::structures::paging::page_table::{PageTable, PageTableFlags};
+use x86_64::VirtAddr;
+
+use crate::backend::kvm::Hook;
+
+use super::Arch;
+
+/// The x86_64 shim expects the first page to be a zero page, followed by
+/// the page tables.
+#[repr(C, align(4096))]
+pub struct X86 {
+    pub zero: Page,
+    pub pml4t: PageTable,
+    pub pml3t_ident: PageTable,
+}
+
+impl Arch for X86 {
+    fn commit(&mut self, backing: &Map<ReadWrite>, hook: &impl Hook) {
+        use PageTableFlags as Flags;
+
+        let start = VirtAddr::new(backing.addr() as u64);
+        let hv2gp = hook.hv2gp();
+
+        let pml3t_ident_addr = VirtAddr::new(&self.pml3t_ident as *const _ as u64);
+        let pdpte = hv2gp(pml3t_ident_addr, start);
+        self.pml4t[0].set_addr(pdpte, Flags::WRITABLE | Flags::PRESENT);
+
+        let pml3t_addr = hv2gp(start, start);
+        let flags = Flags::HUGE_PAGE | Flags::WRITABLE | Flags::PRESENT;
+        self.pml3t_ident[0].set_addr(pml3t_addr, flags);
+    }
+}

--- a/src/backend/kvm/vm/mod.rs
+++ b/src/backend/kvm/vm/mod.rs
@@ -10,7 +10,7 @@ use crate::backend::{Keep, Thread};
 use cpu::Cpu;
 use mem::Region;
 
-pub use builder::{Builder, Hook, SetupRegion, N_SYSCALL_BLOCKS};
+pub use builder::{Builder, Hook, Hv2GpFn, SetupRegion, N_SYSCALL_BLOCKS};
 pub use kvm_bindings::kvm_segment as KvmSegment;
 pub use kvm_bindings::kvm_userspace_memory_region as KvmUserspaceMemoryRegion;
 
@@ -30,6 +30,7 @@ pub struct Vm {
     syscall_start: VirtAddr,
     shim_entry: PhysAddr,
     shim_start: PhysAddr,
+    hv2gp: Box<Hv2GpFn>,
     cr3: PhysAddr,
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -34,7 +34,7 @@ pub trait Backend {
 
     /// Create a keep instance on this backend, measure the keep
     /// and output a json record for the specific backend
-    fn measure(&self, code: Component) -> Result<()>;
+    fn measure(&self, code: Component) -> Result<String>;
 }
 
 pub struct Datum {

--- a/src/backend/sev/builder.rs
+++ b/src/backend/sev/builder.rs
@@ -10,7 +10,6 @@ use sev::launch::{Launcher, Secret};
 use codicon::{Decoder, Encoder};
 use koine::attestation::sev::*;
 use kvm_ioctls::VmFd;
-use openssl::hash::{Hasher, MessageDigest};
 use serde::Deserialize;
 use serde_cbor as serde_flavor;
 use x86_64::{PhysAddr, VirtAddr};
@@ -124,15 +123,5 @@ impl kvm::Hook for Sev {
         Box::new(move |target, start| {
             PhysAddr::new((target.as_u64() - start.as_u64()) | 1 << c_bit_loc)
         })
-    }
-
-    fn measure(&mut self, _vm: &mut VmFd, saddr_space: &[u8]) -> Result<()> {
-        let mut hasher = Hasher::new(MessageDigest::sha256())?;
-        hasher.update(saddr_space)?;
-        let digest = hasher.finish()?;
-
-        println!(r#"{{ "backend": "sev", "sha256": {:?} }}"#, digest);
-
-        Ok(())
     }
 }

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -5,6 +5,7 @@ mod unattested_launch;
 
 use crate::backend::kvm::Builder;
 use crate::backend::kvm::SHIM;
+use crate::backend::kvm::X86;
 use crate::backend::probe::x86_64::{CpuId, Vendor};
 use crate::backend::{self, Datum, Keep};
 use crate::binary::Component;
@@ -253,7 +254,7 @@ impl backend::Backend for Backend {
             }
         };
 
-        let vm = Builder::new(shim, code, builder::Sev::new(sock)).build()?;
+        let vm = Builder::new(shim, code, builder::Sev::new(sock)).build::<X86>()?;
 
         Ok(Arc::new(RwLock::new(vm)))
     }
@@ -262,6 +263,6 @@ impl backend::Backend for Backend {
         let shim = Component::from_bytes(SHIM)?;
         let (_, sock) = UnixStream::pair()?;
 
-        Builder::new(shim, code, builder::Sev::new(sock)).measure()
+        Builder::new(shim, code, builder::Sev::new(sock)).measure::<X86>()
     }
 }

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -255,15 +255,16 @@ impl backend::Backend for Backend {
         Ok(Arc::new(RwLock::new(vm)))
     }
 
-    fn measure(&self, code: Component) -> Result<()> {
+    fn measure(&self, code: Component) -> Result<String> {
         let shim = Component::from_bytes(SHIM)?;
         let sock = attestation_bridge(None)?;
 
         let digest = Builder::new(shim, code, builder::Sev::new(sock))
             .build::<X86>()?
             .measurement(MessageDigest::sha256())?;
-        println!(r#"{{ "backend": "sev", "sha256": {:?} }}"#, digest);
-        Ok(())
+
+        let json = format!(r#"{{ "backend": "sev", "sha256": {:?} }}"#, digest);
+        Ok(json)
     }
 }
 

--- a/src/backend/sgx/mod.rs
+++ b/src/backend/sgx/mod.rs
@@ -144,7 +144,7 @@ impl crate::backend::Backend for Backend {
         Ok(builder.build()?)
     }
 
-    fn measure(&self, mut _code: Component) -> Result<()> {
+    fn measure(&self, mut _code: Component) -> Result<String> {
         unimplemented!()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,8 @@ fn measure(backends: &[Box<dyn Backend>], opts: Report) -> Result<()> {
 
     if let Some(backend) = backend {
         let code = Component::from_path(&opts.code)?;
-        backend.measure(code)?;
+        let json = backend.measure(code)?;
+        println!("{}", json);
     } else {
         panic!(
             "Keep backend '{}' is unsupported.",


### PR DESCRIPTION
The loader is having some growing pains. Let's rearrange some stuff to make it easier to add other stuff.

* Update builder address translation hook to return a closure
* Express syscall blocks as Span for Vm
* Factor out VM construction into modular components
* Move measurement functionality out of Builder::Hook
* Propagate measurement JSON to subcommand so it can print it