### PR TITLE
feat(shim-sev): Use multiple sallyport blocks in parallel

### DIFF
--- a/internal/shim-sev/src/spin.rs
+++ b/internal/shim-sev/src/spin.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! wrapper around spinning types to permit trait implementations.
+
+use spinning::{Mutex, MutexGuard, RawMutex, RawRwLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// A wrapper around spinning::Mutex to permit trait implementations.
+pub struct Locked<A> {
+    inner: Mutex<A>,
+}
+
+impl<A> Locked<A> {
+    /// Constructor
+    #[inline]
+    pub const fn new(inner: A) -> Self {
+        Self {
+            inner: Mutex::const_new(RawMutex::const_new(), inner),
+        }
+    }
+
+    /// get a [`MutexGuard`](spinning::MutexGuard)
+    #[inline]
+    pub fn lock(&self) -> MutexGuard<A> {
+        self.inner.lock()
+    }
+}
+
+/// A wrapper around spinning::RwLock to permit trait implementations.
+pub struct RWLocked<A> {
+    inner: RwLock<A>,
+}
+
+impl<A> RWLocked<A> {
+    /// Constructor
+    #[inline]
+    pub const fn new(inner: A) -> Self {
+        Self {
+            inner: RwLock::const_new(RawRwLock::const_new(), inner),
+        }
+    }
+
+    /// get a [`RwLockReadGuard`](spinning::RwLockReadGuard)
+    #[inline]
+    pub fn read(&self) -> RwLockReadGuard<A> {
+        self.inner.read()
+    }
+
+    /// get a [`RwLockWriteGuard`](spinning::RwLockWriteGuard)
+    #[inline]
+    pub fn write(&self) -> RwLockWriteGuard<A> {
+        self.inner.write()
+    }
+}


### PR DESCRIPTION
This patch enables us to communicate with the Host via multiple
sallyport::Blocks in parallel.

A global HostCallAllocator is added, where one can allocate one
sallyport::Block encapsulated in a `HostCall` type.

This patch also adds the `spin` module, which wraps `spinning::Mutex`
and `spinning::RWLock`, so we can use `impl` on our own types.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
