### PR TITLE
feat(shim-sev): Refactor exit() and exit_group()

### DIFF
--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -7,7 +7,7 @@ use crate::allocator::ALLOCATOR;
 use crate::asm::_enarx_asm_triple_fault;
 use crate::attestation::SEV_SECRET;
 use crate::eprintln;
-use crate::hostcall::{self, HostCall, HOST_CALL};
+use crate::hostcall::{HostCall, HOST_CALL};
 use crate::paging::SHIM_PAGETABLE;
 use crate::payload::{NEXT_BRK_RWLOCK, NEXT_MMAP_RWLOCK};
 use core::convert::TryFrom;
@@ -241,16 +241,6 @@ impl SyscallHandler for Handler {
             }
             None => Err(libc::ENOSYS),
         }
-    }
-
-    fn exit(&mut self, status: i32) -> ! {
-        self.trace("exit", 1);
-        hostcall::shim_exit(status);
-    }
-
-    fn exit_group(&mut self, status: i32) -> ! {
-        self.trace("exit_group", 1);
-        hostcall::shim_exit(status);
     }
 
     fn arch_prctl(&mut self, code: i32, addr: u64) -> sallyport::Result {

--- a/internal/shim-sgx/src/handler.rs
+++ b/internal/shim-sgx/src/handler.rs
@@ -191,29 +191,6 @@ impl<'a> SyscallHandler for Handler<'a> {
         debugln!(self, ")");
     }
 
-    /// Proxy an exit() syscall
-    fn exit(&mut self, status: libc::c_int) -> ! {
-        self.trace("exit", 1);
-
-        #[allow(unused_must_use)]
-        loop {
-            unsafe { self.proxy(request!(libc::SYS_exit => status)) };
-        }
-    }
-
-    /// Proxy an exitgroup() syscall
-    ///
-    /// TODO: Currently we are only using one thread, so this will behave the
-    /// same way as exit(). In the future, this implementation will change.
-    fn exit_group(&mut self, status: libc::c_int) -> ! {
-        self.trace("exit_group", 1);
-
-        #[allow(unused_must_use)]
-        loop {
-            unsafe { self.proxy(request!(libc::SYS_exit_group => status)) };
-        }
-    }
-
     /// Do an arch_prctl() syscall
     fn arch_prctl(&mut self, code: libc::c_int, addr: libc::c_ulong) -> sallyport::Result {
         self.trace("arch_prctl", 2);


### PR DESCRIPTION
Use normal sallyport syscall proxying for `exit()` and `exit_group()`
for all shims.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
