### PR TITLE
Add VM runtime personalities with its first event: memory pinning when ballooning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "codicon",
  "colorful",
  "goblin 0.3.0",
+ "iocuddle",
  "koine",
  "kvm-bindings",
  "kvm-ioctls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ kvm-bindings = { version = "0.3", optional = true }
 kvm-ioctls = { version = "0.6", optional = true }
 primordial = "0.1"
 structopt = "0.3"
+iocuddle = "0.1"
 colorful = "0.2"
 codicon = "3.0"
 mmarinus = "0.2"

--- a/src/backend/kvm/vm/personality.rs
+++ b/src/backend/kvm/vm/personality.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use kvm_ioctls::VmFd;
+
+use super::KvmUserspaceMemoryRegion;
+
+/// The `Personality` trait hooks into events that occur during
+/// runtime.
+///
+/// This allows implementors the ability to respond to certain
+/// events as needed.
+///
+/// If a personality is not needed, pass in Unit.
+pub trait Personality {
+    fn add_memory(_vm: &VmFd, _region: &KvmUserspaceMemoryRegion) {}
+}
+
+impl Personality for () {}

--- a/src/backend/sev/ioctl/mod.rs
+++ b/src/backend/sev/ioctl/mod.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod types;
+
+use iocuddle::{Group, Ioctl, Read, Write};
+
+pub use types::{KvmEncRegion, KvmUserspaceMemoryRegion};
+
+const KVM: Group = Group::new(0xAE);
+
+/// Instruct the kernel that the supplied memory range is encrypted
+/// and therefore the kernel must pin the pages.
+///
+/// Note: this ioctl's direction is wrong in the kernel headers:
+/// _IOR(KVMIO, 0xbb, struct kvm_enc_region), so we will declare
+/// it as read and use `iocuddle`'s lie mechanism to represent
+/// the correct semantics of the ioctl.
+const IOR_ENCRYPT_REGION: Ioctl<Read, &KvmEncRegion> = unsafe { KVM.read(0xBB) };
+pub const ENCRYPT_REGION: Ioctl<Write, &KvmEncRegion> = unsafe { IOR_ENCRYPT_REGION.lie() };

--- a/src/backend/sev/ioctl/types.rs
+++ b/src/backend/sev/ioctl/types.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::marker::PhantomData;
+
+pub use kvm_bindings::kvm_userspace_memory_region as KvmUserspaceMemoryRegion;
+
+#[repr(C)]
+pub struct KvmEncRegion<'a> {
+    addr: u64,
+    size: u64,
+    _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> KvmEncRegion<'a> {
+    pub fn new(region: &'a KvmUserspaceMemoryRegion) -> Self {
+        Self {
+            addr: region.userspace_addr,
+            size: region.memory_size,
+            _phantom: PhantomData,
+        }
+    }
+}

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod builder;
+mod personality;
 mod unattested_launch;
 
 use crate::backend::kvm::Builder;
@@ -249,7 +250,7 @@ impl backend::Backend for Backend {
         let sock = attestation_bridge(sock)?;
 
         let vm = Builder::new(shim, code, builder::Sev::new(sock))
-            .build::<X86>()?
+            .build::<X86, personality::Sev>()?
             .vm();
 
         Ok(Arc::new(RwLock::new(vm)))
@@ -260,7 +261,7 @@ impl backend::Backend for Backend {
         let sock = attestation_bridge(None)?;
 
         let digest = Builder::new(shim, code, builder::Sev::new(sock))
-            .build::<X86>()?
+            .build::<X86, ()>()?
             .measurement(MessageDigest::sha256())?;
 
         let json = format!(r#"{{ "backend": "sev", "sha256": {:?} }}"#, digest);

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod builder;
+mod ioctl;
 mod personality;
+mod runtime;
 mod unattested_launch;
 
 use crate::backend::kvm::Builder;

--- a/src/backend/sev/personality.rs
+++ b/src/backend/sev/personality.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::backend::kvm::Personality;
+
+pub struct Sev;
+
+impl Personality for Sev {}

--- a/src/backend/sev/personality.rs
+++ b/src/backend/sev/personality.rs
@@ -1,7 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::backend::kvm::Personality;
+use kvm_ioctls::VmFd;
+
+use super::ioctl::KvmUserspaceMemoryRegion;
+use super::runtime::mark_encrypted;
 
 pub struct Sev;
 
-impl Personality for Sev {}
+impl Personality for Sev {
+    fn add_memory(vm: &VmFd, region: &KvmUserspaceMemoryRegion) {
+        mark_encrypted(vm, region).expect("SEV memory pinning failed");
+    }
+}

--- a/src/backend/sev/runtime.rs
+++ b/src/backend/sev/runtime.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Result;
+use std::os::unix::io::AsRawFd;
+
+use super::ioctl::{KvmEncRegion, KvmUserspaceMemoryRegion, ENCRYPT_REGION};
+
+pub fn mark_encrypted(kvm_fd: &impl AsRawFd, region: &KvmUserspaceMemoryRegion) -> Result<()> {
+    let enc_region = KvmEncRegion::new(region);
+    ENCRYPT_REGION
+        .ioctl(&mut kvm_fd.as_raw_fd(), &enc_region)
+        .map(|_| ())
+}

--- a/tests/bin/memspike.rs
+++ b/tests/bin/memspike.rs
@@ -1,0 +1,11 @@
+//! `memspike`'s primary intention is to trigger memory ballooning in
+//! VM-based keeps. This will help test the ballooning itself as well
+//! as memory pinning for SEV.
+
+use std::io;
+
+fn main() -> io::Result<()> {
+    let _alloc: Vec<u8> = Vec::with_capacity(40_000_000);
+
+    Ok(())
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -341,3 +341,9 @@ fn bind() {
 fn listen() {
     run_test("listen", 0, None, None, None);
 }
+
+#[test]
+#[serial]
+fn memspike() {
+    run_test("memspike", 0, None, None, None);
+}


### PR DESCRIPTION
* Add a VM personality framework
* Add support for runtime SEV memory pinning

The included `memspike` integration test can be used to check that pages are getting pinned when ballooning (look for the successful `KVM_MEMORY_ENCRYPT_REG_REGION` near the bottom where we see additional memory getting hotplugged):

```console
strace -Te trace=ioctl --decode-fds=path ./target/debug/enarx-keepldr exec target/debug/build/enarx-keepldr-1667cd10683671e6/out/bin/memspike
ioctl(3</dev/kvm>, KVM_GET_API_VERSION, 0) = 12 <0.000006>
ioctl(5</dev/kvm>, KVM_CREATE_VM, 0)    = 6<anon_inode:kvm-vm> <0.000275>
ioctl(5</dev/kvm>, KVM_GET_VCPU_MMAP_SIZE, 0) = 12288 <0.000005>
ioctl(6<anon_inode:kvm-vm>, KVM_SET_USER_MEMORY_REGION, {slot=0, flags=0, guest_phys_addr=0, memory_size=39845888, userspace_addr=0x7fe9ecb43000}) = 0 <0.000026>
ioctl(7</dev/sev>, SEV_ISSUE_CMD, 0x7ffe4560a1e0) = 0 <0.000226>
ioctl(6<anon_inode:kvm-vm>, KVM_MEMORY_ENCRYPT_OP, 0x7ffe4560a1f8) = 0 <0.000008>
ioctl(6<anon_inode:kvm-vm>, KVM_MEMORY_ENCRYPT_OP, 0x7ffe4560a198) = 0 <0.003965>
ioctl(6<anon_inode:kvm-vm>, KVM_MEMORY_ENCRYPT_OP, 0x7ffe4560a1d8) = 0 <4.693806>
ioctl(6<anon_inode:kvm-vm>, KVM_MEMORY_ENCRYPT_OP, 0x7ffe4560a0a8) = 0 <0.000468>
ioctl(6<anon_inode:kvm-vm>, KVM_MEMORY_ENCRYPT_OP, 0x7ffe4560a208) = 0 <0.000447>
ioctl(6<anon_inode:kvm-vm>, KVM_CREATE_VCPU, 0) = 3<anon_inode:kvm-vcpu:0> <0.000237>
ioctl(3<anon_inode:kvm-vcpu:0>, KVM_GET_REGS, {rax=0, ..., rsp=0, rbp=0, ..., rip=0xfff0, rflags=0x2}) = 0 <0.000012>
ioctl(3<anon_inode:kvm-vcpu:0>, KVM_SET_REGS, {rax=0, ..., rsp=0, rbp=0, ..., rip=0xfff0, rflags=0x2}) = 0 <0.000010>
ioctl(5</dev/kvm>, KVM_GET_SUPPORTED_CPUID, {nent=59, entries=[...]}) = 0 <0.000023>
ioctl(3<anon_inode:kvm-vcpu:0>, KVM_SET_CPUID2, {nent=59, entries=[...]}) = 0 <0.000012>
ioctl(3<anon_inode:kvm-vcpu:0>, KVM_GET_REGS, {rax=0, ..., rsp=0, rbp=0, ..., rip=0xfff0, rflags=0x2}) = 0 <0.000009>
ioctl(3<anon_inode:kvm-vcpu:0>, KVM_SET_REGS, {rax=0, ..., rsp=0, rbp=0, ..., rip=0x237c30, rflags=0x2}) = 0 <0.000010>
ioctl(3<anon_inode:kvm-vcpu:0>, KVM_GET_SREGS, {cs={base=0xffff0000, limit=65535, selector=61440, type=10, present=1, dpl=0, db=0, s=1, l=0, g=0, avl=0}, ...}) = 0 <0.000010>
ioctl(3<anon_inode:kvm-vcpu:0>, KVM_SET_SREGS, {cs={base=0, limit=1048575, selector=8, type=11, present=1, dpl=0, db=0, s=1, l=1, g=1, avl=0}, ...}) = 0 <0.000012>
ioctl(3<anon_inode:kvm-vcpu:0>, KVM_RUN, 0) = 0 <0.000189>
ioctl(5</dev/kvm>, KVM_CHECK_EXTENSION, KVM_CAP_NR_MEMSLOTS) = 509 <0.000008>
ioctl(3<anon_inode:kvm-vcpu:0>, KVM_RUN, 0) = 0 <0.001236>
ioctl(3<anon_inode:kvm-vcpu:0>, KVM_RUN, 0) = 0 <0.000632>
ioctl(6<anon_inode:kvm-vm>, KVM_SET_USER_MEMORY_REGION, {slot=1, flags=0, guest_phys_addr=0x2600000, memory_size=69877760, userspace_addr=0x7fe9e3d5c000}) = 0 <0.000047>
ioctl(6<anon_inode:kvm-vm>, KVM_MEMORY_ENCRYPT_REG_REGION, 0x7ffe4561ada0) = 0 <0.019310>
ioctl(3<anon_inode:kvm-vcpu:0>, KVM_RUN, 0) = 0 <0.018695>
+++ exited with 0 +++
```

Closes #55 