### PR TITLE
Revert "fix(shim-sev): add an addition 32MB to the memory"

### DIFF
--- a/internal/shim-sev/src/hostlib.rs
+++ b/internal/shim-sev/src/hostlib.rs
@@ -144,7 +144,6 @@ impl BootInfo {
     ///
     /// `NoMemory`: if there is not enough memory for the shim to operate
     #[inline]
-    #[allow(clippy::integer_arithmetic)]
     pub fn calculate(
         setup: Line<usize>,
         shim: Span<usize>,
@@ -165,9 +164,7 @@ impl BootInfo {
             .ok_or(NoMemory(()))?
             .into();
 
-        let mut mem_size = raise(code.end, Page::size()).ok_or(NoMemory(()))?;
-        // Initial space for basic memory allocations
-        mem_size = mem_size.checked_add(bytes!(32; MiB)).unwrap();
+        let mem_size = raise(code.end, Page::size()).ok_or(NoMemory(()))?;
 
         Ok(Self {
             setup,


### PR DESCRIPTION
This reverts commit 7b6e23eb00d644120ddadfbf76b54ac0b7ebf3d5.

Apparently this patch causes 4 more seconds on VM startup time.

Measuring the `exit_zero` integration_tests test gives:

```
❯ hyperfine "target/release/deps/integration_tests-b64a094b34c0b68f exit_zero"
Benchmark #1: target/release/deps/integration_tests-b64a094b34c0b68f exit_zero
  Time (mean ± σ):      4.720 s ±  0.012 s    [User: 15.1 ms, System: 49.1 ms]
  Range (min … max):    4.687 s …  4.729 s    10 runs
```

And with this patch reverted:

```
❯ hyperfine "target/release/deps/integration_tests-b64a094b34c0b68f exit_zero"
Benchmark #1: target/release/deps/integration_tests-b64a094b34c0b68f exit_zero
  Time (mean ± σ):     793.7 ms ±   0.4 ms    [User: 12.7 ms, System: 45.5 ms]
  Range (min … max):   793.1 ms … 794.4 ms    10 runs
```

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
