### PR TITLE
fix(loader): Minimize memory size

### DIFF
--- a/src/backend/kvm/vm/builder.rs
+++ b/src/backend/kvm/vm/builder.rs
@@ -11,7 +11,6 @@ use anyhow::Result;
 use kvm_ioctls::{Kvm, VmFd};
 use lset::{Line, Span};
 use mmarinus::{perms, Kind, Map};
-use nbytes::bytes;
 use openssl::hash::{DigestBytes, Hasher, MessageDigest};
 use x86_64::{align_up, PhysAddr, VirtAddr};
 
@@ -74,7 +73,7 @@ impl<T: Hook> Builder<T> {
             self.code.region().into(),
         )?;
 
-        let mem_size = align_up(boot_info.mem_size as _, bytes![2; MiB]);
+        let mem_size = align_up(boot_info.mem_size as _, size_of::<Page>() as _);
         // fill out remaining fields of `BootInfo`
         boot_info.nr_syscall_blocks = num_syscall_blocks::<A>();
         boot_info.mem_size = mem_size as _;


### PR DESCRIPTION
Limit the initial memory space to a minimum and don't align up
needlessly. VM encryption speed of 8MB/s is extremely slow.

Before:

```console
❯ hyperfine "target/release/enarx-keepldr exec ./target/release/build/enarx-keepldr*/out/bin/exit_zero "
Benchmark #1: target/release/enarx-keepldr exec ./target/release/build/enarx-keepldr*/out/bin/exit_zero
  Time (mean ± σ):     769.2 ms ±   0.8 ms    [User: 12.2 ms, System: 20.8 ms]
  Range (min … max):   768.2 ms … 770.8 ms    10 runs
```

After:

```
❯ hyperfine "target/release/enarx-keepldr exec ./target/release/build/enarx-keepldr*/out/bin/exit_zero "
Benchmark #1: target/release/enarx-keepldr exec ./target/release/build/enarx-keepldr*/out/bin/exit_zero
  Time (mean ± σ):     537.6 ms ±   3.1 ms    [User: 11.3 ms, System: 20.2 ms]
  Range (min … max):   529.4 ms … 540.0 ms    10 runs
```

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
