### PR TITLE
Auto-clean Unix sockets created during testing

### DIFF
--- a/tests/bin/unix_echo.rs
+++ b/tests/bin/unix_echo.rs
@@ -1,14 +1,55 @@
 use std::io::{self, Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 
+use std::path::{Path, PathBuf};
+
+struct TidySocket<T> {
+    path: PathBuf,
+    socket: T,
+}
+
+impl<T> TidySocket<T> {
+    fn new<P: AsRef<Path>>(path: P, sock: T) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+            socket: sock,
+        }
+    }
+}
+
+impl<T> std::ops::Deref for TidySocket<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.socket
+    }
+}
+
+impl<T> std::ops::DerefMut for TidySocket<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.socket
+    }
+}
+
+impl<T> std::ops::Drop for TidySocket<T> {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
 fn main() -> io::Result<()> {
-    let listener = UnixListener::bind("/tmp/enarx_unix_echo_to_bin")?;
+    let listen_path = "/tmp/enarx_unix_echo_to_bin";
+    let listener = UnixListener::bind(listen_path).map(|l| TidySocket::new(listen_path, l))?;
+
     let (mut socket, _) = listener.accept()?;
 
     let mut buffer = Vec::new();
     socket.read_to_end(&mut buffer)?;
 
-    let mut socket = UnixStream::connect("/tmp/enarx_unix_echo_from_bin").unwrap();
+    let from_path = "/tmp/enarx_unix_echo_from_bin";
+    let mut socket = UnixStream::connect(from_path)
+        .map(|s| TidySocket::new(from_path, s))
+        .unwrap();
     socket.write_all(&buffer)?;
     Ok(())
 }


### PR DESCRIPTION
This isn't so much a problem for running tests inside our container, but when developing locally, the unix socket test will fail if the socket is leftover in the /tmp directory:

```console
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 98, kind: AddrInUse, message: "Address already in use" }', tests/integration_tests.rs:254:61
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'unix_echo' panicked at 'process `unix_echo` timed out', tests/integration_tests.rs:85:28
```

Consequently, @haraldh would you mind removing this file that belongs to your user: `/tmp/enarx_unix_echo_from_bin` on Rome :-)

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>
