### PR TITLE
Remove unnecessary certificate chain caching step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,6 @@ jobs:
           target: x86_64-unknown-linux-musl
           toolchain: nightly
           override: true
-      - name: "SEV: Cache certificate chain"
-        if: ${{ matrix.backend.name == 'sev' }}
-        run: |
-          cargo install --locked --git https://github.com/enarx/sevctl --rev ac264b44 sevctl
-          mkdir -p ~/.cache/amd-sev
-          sevctl export --full ~/.cache/amd-sev/chain
       - uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
Closes https://github.com/enarx/sev/issues/25.

Drafted until Rome has been re-kicked since the kickstart file is responsible for caching the certificate chain and mounting it into the GHA container.

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>
