### PR TITLE
Take clippy suggestion to use &Path instead of &PathBuf

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -111,7 +111,7 @@ fn build_cc_tests(in_path: &Path, out_path: &Path) {
     }
 }
 
-fn create(path: &PathBuf) {
+fn create(path: &Path) {
     match std::fs::create_dir(&path) {
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
         Err(e) => {


### PR DESCRIPTION
Otherwise CI fails with its newly updated clippy definitions

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>