### PR TITLE
Measure VM address space before code_loaded hook

### DIFF
--- a/src/backend/kvm/vm/measure.rs
+++ b/src/backend/kvm/vm/measure.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+
+use openssl::hash::{DigestBytes, MessageDigest};
+
+#[derive(Copy, Clone, Debug)]
+pub enum Kind {
+    Sha256,
+    Null,
+}
+
+impl fmt::Display for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Sha256 => "sha256",
+            Self::Null => "null",
+        };
+
+        write!(f, "{}", s)
+    }
+}
+
+impl From<Kind> for MessageDigest {
+    fn from(k: Kind) -> MessageDigest {
+        match k {
+            Kind::Sha256 => MessageDigest::sha256(),
+            Kind::Null => MessageDigest::null(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Measurement {
+    pub kind: Kind,
+    pub digest: DigestBytes,
+}

--- a/src/backend/kvm/vm/mod.rs
+++ b/src/backend/kvm/vm/mod.rs
@@ -3,6 +3,7 @@
 pub mod builder;
 mod cpu;
 pub mod image;
+pub mod measure;
 mod mem;
 pub mod personality;
 

--- a/src/backend/sev/builder.rs
+++ b/src/backend/sev/builder.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::backend::kvm;
 use crate::backend::kvm::shim::{BootInfo, SevSecret};
 use crate::backend::kvm::Hv2GpFn;
+use crate::backend::kvm::{self, measure};
 
 use sev::firmware::Firmware;
 use sev::launch::{Launcher, Secret};
@@ -26,6 +26,10 @@ impl Sev {
 }
 
 impl kvm::Hook for Sev {
+    fn preferred_digest() -> measure::Kind {
+        measure::Kind::Sha256
+    }
+
     fn code_loaded(
         &mut self,
         vm: &mut VmFd,

--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -14,7 +14,6 @@ use crate::backend::{self, Datum, Keep};
 use crate::binary::Component;
 
 use anyhow::Result;
-use openssl::hash::MessageDigest;
 
 use std::arch::x86_64::__cpuid_count;
 use std::fs::OpenOptions;
@@ -264,9 +263,12 @@ impl backend::Backend for Backend {
 
         let digest = Builder::new(shim, code, builder::Sev::new(sock))
             .build::<X86, ()>()?
-            .measurement(MessageDigest::sha256())?;
+            .measurement();
 
-        let json = format!(r#"{{ "backend": "sev", "sha256": {:?} }}"#, digest);
+        let json = format!(
+            r#"{{ "backend": "sev", "{}": {:?} }}"#,
+            digest.kind, digest.digest
+        );
         Ok(json)
     }
 }


### PR DESCRIPTION
This is the final hook where the SEV backend will encrypt
the address space. Taking the measurement post-encryption
is not what we want. We want the measurement of the state
_before_ encryption; otherwise the measurement will change
with each launch even though the binaries are the same.

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>

Closes #282 

**Before**:

```console
$ ENARX_BACKEND=sev ./target/debug/enarx-keepldr report $WASMLDR
{ "backend": "sev", "sha256": [136, 239, 163, 55, 213, 146, 79, 160, 137, 181, 165, 140, 132, 105, 224, 21, 181, 235, 88, 69, 118, 155, 74, 149, 184, 234, 5, 83, 75, 99, 201, 226] }
$ ENARX_BACKEND=sev ./target/debug/enarx-keepldr report $WASMLDR
{ "backend": "sev", "sha256": [240, 172, 207, 232, 1, 64, 242, 35, 41, 2, 168, 42, 20, 157, 13, 14, 228, 117, 72, 66, 24, 26, 2, 132, 190, 43, 216, 45, 177, 59, 156, 33] }
$ ENARX_BACKEND=sev ./target/debug/enarx-keepldr report $WASMLDR
{ "backend": "sev", "sha256": [200, 104, 166, 168, 202, 206, 159, 247, 146, 233, 187, 22, 54, 141, 225, 0, 244, 38, 59, 85, 117, 62, 49, 201, 62, 94, 206, 49, 188, 99, 3, 242] }
```

**After**:

```console
$ ENARX_BACKEND=sev ./target/debug/enarx-keepldr report $WASMLDR
{ "backend": "sev", "sha256": [147, 178, 26, 191, 82, 212, 112, 197, 242, 39, 5, 129, 22, 152, 97, 220, 186, 1, 153, 243, 218, 226, 150, 73, 54, 145, 15, 162, 242, 71, 70, 32] }
$ ENARX_BACKEND=sev ./target/debug/enarx-keepldr report $WASMLDR
{ "backend": "sev", "sha256": [147, 178, 26, 191, 82, 212, 112, 197, 242, 39, 5, 129, 22, 152, 97, 220, 186, 1, 153, 243, 218, 226, 150, 73, 54, 145, 15, 162, 242, 71, 70, 32] }
$ ENARX_BACKEND=sev ./target/debug/enarx-keepldr report $WASMLDR
{ "backend": "sev", "sha256": [147, 178, 26, 191, 82, 212, 112, 197, 242, 39, 5, 129, 22, 152, 97, 220, 186, 1, 153, 243, 218, 226, 150, 73, 54, 145, 15, 162, 242, 71, 70, 32] }

```