### PR TITLE
Update SGX attestation to get V3 Quote

### DIFF
--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -38,7 +38,7 @@ pub const SGX_TECH: usize = 2;
 /// Size in bytes of expected SGX Quote
 // TODO: Determine length of Quote of PCK cert type
 #[allow(dead_code)]
-pub const SGX_QUOTE_SIZE: usize = 1244;
+pub const SGX_QUOTE_SIZE: usize = 4598;
 
 /// Size in bytes of expected SGX QE TargetInfo
 #[allow(dead_code)]

--- a/tests/bin/get_att.c
+++ b/tests/bin/get_att.c
@@ -5,7 +5,7 @@
 int main(void) {
     // TODO: Good buffer length?
     unsigned char nonce[512];
-    unsigned char buf[1244];
+    unsigned char buf[4598];
     size_t technology;
 
     ssize_t size = get_att(nonce, sizeof(nonce), buf, sizeof(buf), &technology);

--- a/tests/bin/sgx_get_att_quote.c
+++ b/tests/bin/sgx_get_att_quote.c
@@ -10,7 +10,7 @@
 
 int main(void) {
     int* nonce = NULL;
-    unsigned char buf[1244];
+    unsigned char buf[4598];
     size_t technology;
 
     ssize_t size = get_att(nonce, sizeof(nonce), buf, sizeof(buf), &technology);


### PR DESCRIPTION
The V3 Quote is necessary for the DCAP attestation that we are using.

I'm hoping to eventually do a bit more cleanup around error handling, etc.

In this PR:
- Refactor of SGX attestation code (factor out setting protobuf message fields and sending and receiving
protobuf messages to remove redundancy before adding extra API calls)
- Moving the AESM connection detection (and return of dummy values if no connection) to be done only once (again to remove redundancy before adding more API calls)
- Adding extra API necessary for V3: getting attestation key ID
- Adding extra API necessary for V3: getting attestation key size
- Updating API calls to get V3 Quote