### PR TITLE
fix: validate SEV cert chain and improve error output

### DIFF
--- a/src/backend/sev/mod.rs
+++ b/src/backend/sev/mod.rs
@@ -278,7 +278,11 @@ fn attestation_bridge(sock: Option<&Path>) -> Result<UnixStream> {
         Some(s) => UnixStream::connect(s)?,
         None => {
             let (synthetic_client, sock) = UnixStream::pair()?;
-            std::thread::spawn(move || unattested_launch::launch(synthetic_client));
+            std::thread::spawn(move || {
+                if let Err(e) = unattested_launch::launch(synthetic_client) {
+                    eprintln!("\nattestation_bridge Error: {:?}", e)
+                }
+            });
             sock
         }
     };


### PR DESCRIPTION
*  feat(backend/sev): add context message to `sev::cached_chain::get()?`
    
    ```
    Error: Failed to read cached certification chain from `/var/cache/amd-sev/chain`
    
    Caused by:
        Permission denied (os error 13)
    ```

* fix(sev): print user friendly attestation_bridge errors

    ```
    Error: Failed to read cached certification chain from `/var/cache/amd-sev/chain`
    
    Caused by:
        Permission denied (os error 13)
    attestation_bridge error: failed to deserialize expected certificate chain
    ```
