### PR TITLE
fix(backend/sgx): satisfy clippy

### DIFF
--- a/src/backend/sgx/mod.rs
+++ b/src/backend/sgx/mod.rs
@@ -62,9 +62,8 @@ impl crate::backend::Backend for Backend {
     }
 
     fn data(&self) -> Vec<Datum> {
-        let mut data = vec![];
+        let mut data = vec![data::dev_sgx_enclave()];
 
-        data.push(data::dev_sgx_enclave());
         data.extend(data::CPUIDS.iter().map(|c| c.into()));
 
         let max = unsafe { __cpuid_count(0x00000000, 0x00000000) }.eax;


### PR DESCRIPTION
error: calls to `push` immediately after creation
```
  --> src/backend/sgx/mod.rs:65:9
   |
65 | /         let mut data = vec![];
66 | |
67 | |         data.push(data::dev_sgx_enclave());
   | |___________________________________________^

```
help: consider using the `vec![]` macro: `let mut data = vec![..];`

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
