### PR TITLE
test: add sev_get_att_quote

### DIFF
--- a/tests/bin/sev_get_att_quote.c
+++ b/tests/bin/sev_get_att_quote.c
@@ -1,0 +1,24 @@
+#include "libc.h"
+#include "enarx.h"
+#include <errno.h>
+
+/* This test will be run only for SEV */
+
+int main(void) {
+    int* nonce = NULL;
+    // TODO Update this buffer size to match real Quote.
+    unsigned char buf[16*1024];
+    size_t technology;
+
+    ssize_t size = get_att(nonce, sizeof(nonce), buf, sizeof(buf), &technology);
+
+    if (technology != TEE_SEV)
+        return 0;
+
+    if (size < 0)
+        return 1;
+
+    write(STDOUT_FILENO, buf, size);
+
+    return 0;
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -311,6 +311,18 @@ fn sgx_get_att_quote() {
     run_test("sgx_get_att_quote", 0, None, None, None);
 }
 
+#[cfg(feature = "backend-sev")]
+#[test]
+#[serial]
+fn sev_get_att_quote() {
+    if let Ok(s) = std::env::var("ENARX_BACKEND") {
+        if s.eq("sev") {
+            let input: Vec<u8> = vec![70, 0, 1, 2, 3, 4, 5];
+            run_test("sev_get_att_quote", 0, None, input.as_slice(), None);
+        }
+    }
+}
+
 #[test]
 #[serial]
 fn getuid() {


### PR DESCRIPTION
Inject a fake secret in the unattested launch and test for it in the
integration tests.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
