### PR TITLE
WIP feat: use primordial git HEAD (future 0.2 release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
  "mmarinus",
  "nbytes",
  "openssl",
- "primordial",
+ "primordial 0.2.0",
  "process_control",
  "protobuf",
  "protobuf-codegen-pure",
@@ -510,6 +510,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "979d94833957a6485c5cac4b71d552a9cd0b9f3f6fd1c7c5dc8096b3ee2bcd13"
 
 [[package]]
+name = "primordial"
+version = "0.2.0"
+source = "git+https://github.com/enarx/primordial#c7eec07d344180ef96534dd95a1d6f113a6c6bbd"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,7 +779,7 @@ dependencies = [
  "lset",
  "mmarinus",
  "openssl",
- "primordial",
+ "primordial 0.1.0",
  "vdso",
  "xsave",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ koine = { git = "https://github.com/enarx/koine", optional = true }
 x86_64 = { version = "0.11", default-features = false, features = ["stable"], optional = true }
 kvm-bindings = { version = "0.3", optional = true }
 kvm-ioctls = { version = "0.6", optional = true }
-primordial = "0.1"
+primordial = { git = "https://github.com/enarx/primordial" }
 structopt = "0.3"
 iocuddle = "0.1"
 ciborium = "0.1"

--- a/internal/sallyport/Cargo.toml
+++ b/internal/sallyport/Cargo.toml
@@ -16,7 +16,7 @@ keywords = [
 
 [dependencies]
 libc = { version = "0.2", features = [] }
-primordial = "0.1"
+primordial = { git = "https://github.com/enarx/primordial" }
 
 [features]
 default = ["std"]

--- a/internal/sgx-heap/Cargo.toml
+++ b/internal/sgx-heap/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 
 [dependencies]
 libc = { version = "0.2", default-features = false }
-primordial = "0.1"
+primordial = { git = "https://github.com/enarx/primordial" }
 lset = "0.1"

--- a/internal/shim-sev/Cargo.lock
+++ b/internal/shim-sev/Cargo.lock
@@ -81,9 +81,8 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "primordial"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "979d94833957a6485c5cac4b71d552a9cd0b9f3f6fd1c7c5dc8096b3ee2bcd13"
+version = "0.2.0"
+source = "git+https://github.com/enarx/primordial#c7eec07d344180ef96534dd95a1d6f113a6c6bbd"
 
 [[package]]
 name = "rcrt1"

--- a/internal/shim-sev/Cargo.toml
+++ b/internal/shim-sev/Cargo.toml
@@ -20,7 +20,7 @@ goblin = { version = "0.3", default-features = false, features = [ "elf64" ] }
 crt0stack = { version = "0.1", default-features = false }
 spinning = { version = "0.1", default-features = false }
 libc = { version = "0.2", default-features = false }
-primordial = "0.1"
+primordial = { git = "https://github.com/enarx/primordial" }
 nbytes = "0.1"
 lset = "0.1"
 array-const-fn-init = "0.1"

--- a/internal/shim-sgx/Cargo.lock
+++ b/internal/shim-sgx/Cargo.lock
@@ -85,6 +85,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "979d94833957a6485c5cac4b71d552a9cd0b9f3f6fd1c7c5dc8096b3ee2bcd13"
 
 [[package]]
+name = "primordial"
+version = "0.2.0"
+source = "git+https://github.com/enarx/primordial#c7eec07d344180ef96534dd95a1d6f113a6c6bbd"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,7 +120,7 @@ name = "sallyport"
 version = "0.1.0"
 dependencies = [
  "libc",
- "primordial",
+ "primordial 0.2.0",
 ]
 
 [[package]]
@@ -132,7 +137,7 @@ dependencies = [
  "bitflags",
  "cc",
  "lset",
- "primordial",
+ "primordial 0.1.0",
  "xsave",
 ]
 
@@ -142,7 +147,7 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "lset",
- "primordial",
+ "primordial 0.2.0",
 ]
 
 [[package]]
@@ -156,7 +161,7 @@ dependencies = [
  "libc",
  "lset",
  "nbytes",
- "primordial",
+ "primordial 0.2.0",
  "rcrt1",
  "sallyport",
  "sgx",
@@ -182,7 +187,7 @@ name = "syscall"
 version = "0.1.0"
 dependencies = [
  "libc",
- "primordial",
+ "primordial 0.2.0",
  "sallyport",
  "untrusted",
 ]
@@ -197,7 +202,7 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 name = "untrusted"
 version = "0.1.0"
 dependencies = [
- "primordial",
+ "primordial 0.2.0",
 ]
 
 [[package]]

--- a/internal/shim-sgx/Cargo.toml
+++ b/internal/shim-sgx/Cargo.toml
@@ -20,7 +20,7 @@ sgx = { git = "https://github.com/enarx/sgx", rev = "5292e53", features = [ "asm
 goblin = { version = "0.3", default-features = false, features = [ "elf64" ] }
 crt0stack = { version = "0.1", default-features = false }
 libc = { version = "0.2", default-features = false }
-primordial = "0.1"
+primordial = { git = "https://github.com/enarx/primordial" }
 nbytes = "0.1"
 lset = "0.1"
 xsave = "0.1.1"

--- a/internal/shim-sgx/src/event.rs
+++ b/internal/shim-sgx/src/event.rs
@@ -31,21 +31,21 @@ pub extern "C" fn event(
             match unsafe { h.aex.gpr.rip.into_slice(2usize) } {
                 OP_SYSCALL => {
                     let ret = h.syscall(
-                        h.aex.gpr.rdi.into(),
-                        h.aex.gpr.rsi.into(),
-                        h.aex.gpr.rdx.into(),
-                        h.aex.gpr.r10.into(),
-                        h.aex.gpr.r8.into(),
-                        h.aex.gpr.r9.into(),
-                        h.aex.gpr.rax.into(),
+                        usize::from(h.aex.gpr.rdi).into(),
+                        usize::from(h.aex.gpr.rsi).into(),
+                        usize::from(h.aex.gpr.rdx).into(),
+                        usize::from(h.aex.gpr.r10).into(),
+                        usize::from(h.aex.gpr.r8).into(),
+                        usize::from(h.aex.gpr.r9).into(),
+                        usize::from(h.aex.gpr.rax).into(),
                     );
 
                     aex.gpr.rip = (usize::from(aex.gpr.rip) + 2).into();
                     match ret {
                         Err(e) => aex.gpr.rax = (-e).into(),
                         Ok([rax, rdx]) => {
-                            aex.gpr.rax = rax.into();
-                            aex.gpr.rdx = rdx.into();
+                            aex.gpr.rax = usize::from(rax).into();
+                            aex.gpr.rdx = usize::from(rdx).into();
                         }
                     }
                 }

--- a/internal/shim-sgx/src/handler.rs
+++ b/internal/shim-sgx/src/handler.rs
@@ -80,7 +80,7 @@ impl<'a> Handler<'a> {
             );
         }
 
-        self.block.msg.req = request!(SYS_ENARX_CPUID => self.aex.gpr.rax, self.aex.gpr.rcx);
+        self.block.msg.req = request!(SYS_ENARX_CPUID => usize::from(self.aex.gpr.rax), usize::from(self.aex.gpr.rcx));
 
         unsafe {
             // prevent earlier writes from being moved beyond this point
@@ -91,10 +91,10 @@ impl<'a> Handler<'a> {
             // prevent later reads from being moved before this point
             core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::Acquire);
 
-            self.aex.gpr.rax = self.block.msg.req.arg[0].into();
-            self.aex.gpr.rbx = self.block.msg.req.arg[1].into();
-            self.aex.gpr.rcx = self.block.msg.req.arg[2].into();
-            self.aex.gpr.rdx = self.block.msg.req.arg[3].into();
+            self.aex.gpr.rax = usize::from(self.block.msg.req.arg[0]).into();
+            self.aex.gpr.rbx = usize::from(self.block.msg.req.arg[1]).into();
+            self.aex.gpr.rcx = usize::from(self.block.msg.req.arg[2]).into();
+            self.aex.gpr.rdx = usize::from(self.block.msg.req.arg[3]).into();
         }
 
         if TRACE {

--- a/internal/syscall/Cargo.toml
+++ b/internal/syscall/Cargo.toml
@@ -12,4 +12,4 @@ publish = false
 sallyport = { path = "../sallyport", default-features = false }
 untrusted = { path = "../untrusted"}
 libc = { version = "0.2", features = [] }
-primordial = "0.1"
+primordial = { git = "https://github.com/enarx/primordial" }

--- a/internal/syscall/src/lib.rs
+++ b/internal/syscall/src/lib.rs
@@ -87,26 +87,36 @@ pub trait SyscallHandler:
             libc::SYS_mmap => self.mmap(
                 a.into(),
                 b.into(),
-                c.try_into().map_err(|_| libc::EINVAL)?,
-                usize::from(d) as _,
-                usize::from(e) as _,
+                c.try_into().or(Err(libc::EINVAL))?,
+                d.try_into().or(Err(libc::EINVAL))?,
+                e.try_into().or(Err(libc::EINVAL))?,
                 f.into(),
             ),
             libc::SYS_munmap => self.munmap(a.into(), b.into()),
-            libc::SYS_madvise => self.madvise(a.into(), b.into(), usize::from(c) as _),
-            libc::SYS_mprotect => self.mprotect(a.into(), b.into(), usize::from(c) as _),
+            libc::SYS_madvise => {
+                self.madvise(a.into(), b.into(), c.try_into().or(Err(libc::EINVAL))?)
+            }
+            libc::SYS_mprotect => {
+                self.mprotect(a.into(), b.into(), c.try_into().or(Err(libc::EINVAL))?)
+            }
 
             // ProcessSyscallHandler
-            libc::SYS_arch_prctl => self.arch_prctl(usize::from(a) as _, b.into()),
-            libc::SYS_exit => self.exit(usize::from(a) as _),
-            libc::SYS_exit_group => self.exit_group(usize::from(a) as _),
+            libc::SYS_arch_prctl => self.arch_prctl(a.try_into().or(Err(libc::EINVAL))?, b.into()),
+            libc::SYS_exit => self.exit(a.try_into().or(Err(libc::EINVAL))?),
+            libc::SYS_exit_group => self.exit_group(a.try_into().or(Err(libc::EINVAL))?),
             libc::SYS_set_tid_address => self.set_tid_address(a.into()),
-            libc::SYS_rt_sigaction => {
-                self.rt_sigaction(usize::from(a) as _, b.into(), c.into(), d.into())
-            }
-            libc::SYS_rt_sigprocmask => {
-                self.rt_sigprocmask(usize::from(a) as _, b.into(), c.into(), d.into())
-            }
+            libc::SYS_rt_sigaction => self.rt_sigaction(
+                a.try_into().or(Err(libc::EINVAL))?,
+                b.into(),
+                c.into(),
+                d.into(),
+            ),
+            libc::SYS_rt_sigprocmask => self.rt_sigprocmask(
+                a.try_into().or(Err(libc::EINVAL))?,
+                b.into(),
+                c.into(),
+                d.into(),
+            ),
             libc::SYS_sigaltstack => self.sigaltstack(a.into(), b.into()),
             libc::SYS_getpid => self.getpid(),
             libc::SYS_getuid => self.getuid(),
@@ -115,83 +125,107 @@ pub trait SyscallHandler:
             libc::SYS_getegid => self.getegid(),
 
             // SystemSyscallHandler
-            libc::SYS_getrandom => self.getrandom(a.into(), b.into(), usize::from(c) as _),
-            libc::SYS_clock_gettime => self.clock_gettime(usize::from(a) as _, b.into()),
+            libc::SYS_getrandom => {
+                self.getrandom(a.into(), b.into(), c.try_into().or(Err(libc::EINVAL))?)
+            }
+            libc::SYS_clock_gettime => {
+                self.clock_gettime(a.try_into().or(Err(libc::EINVAL))?, b.into())
+            }
             libc::SYS_uname => self.uname(a.into()),
 
             // FileSyscallHandler
-            libc::SYS_close => self.close(a.try_into().map_err(|_| libc::EINVAL)?),
-            libc::SYS_read => self.read(usize::from(a) as _, b.into(), c.into()),
-            libc::SYS_readv => self.readv(usize::from(a) as _, b.into(), usize::from(c) as _),
-            libc::SYS_write => self.write(usize::from(a) as _, b.into(), c.into()),
-            libc::SYS_writev => self.writev(usize::from(a) as _, b.into(), usize::from(c) as _),
-            libc::SYS_ioctl => self.ioctl(usize::from(a) as _, b.into(), c.into()),
-            libc::SYS_readlink => self.readlink(a.into(), b.into(), c.into()),
-            libc::SYS_fstat => self.fstat(usize::from(a) as _, b.into()),
-            libc::SYS_fcntl => self.fcntl(
-                usize::from(a) as _,
-                usize::from(b) as _,
-                usize::from(c) as _,
+            libc::SYS_close => self.close(a.try_into().or(Err(libc::EINVAL))?),
+            libc::SYS_read => self.read(a.try_into().or(Err(libc::EINVAL))?, b.into(), c.into()),
+            libc::SYS_readv => self.readv(
+                a.try_into().or(Err(libc::EINVAL))?,
+                b.into(),
+                c.try_into().or(Err(libc::EINVAL))?,
             ),
-            libc::SYS_poll => self.poll(a.into(), b.into(), usize::from(c) as _),
+            libc::SYS_write => self.write(a.try_into().or(Err(libc::EINVAL))?, b.into(), c.into()),
+            libc::SYS_writev => self.writev(
+                a.try_into().or(Err(libc::EINVAL))?,
+                b.into(),
+                c.try_into().or(Err(libc::EINVAL))?,
+            ),
+            libc::SYS_ioctl => self.ioctl(a.try_into().or(Err(libc::EINVAL))?, b.into(), c.into()),
+            libc::SYS_readlink => self.readlink(a.into(), b.into(), c.into()),
+            libc::SYS_fstat => self.fstat(a.try_into().or(Err(libc::EINVAL))?, b.into()),
+            libc::SYS_fcntl => self.fcntl(
+                a.try_into().or(Err(libc::EINVAL))?,
+                b.try_into().or(Err(libc::EINVAL))?,
+                c.try_into().or(Err(libc::EINVAL))?,
+            ),
+            libc::SYS_poll => self.poll(a.into(), b.into(), c.try_into().or(Err(libc::EINVAL))?),
             libc::SYS_pipe => self.pipe(a.into()),
-            libc::SYS_epoll_create1 => self.epoll_create1(a.try_into().map_err(|_| libc::EINVAL)?),
+            libc::SYS_epoll_create1 => self.epoll_create1(a.try_into().or(Err(libc::EINVAL))?),
             libc::SYS_epoll_ctl => self.epoll_ctl(
-                usize::from(a) as _,
-                usize::from(b) as _,
-                usize::from(c) as _,
+                a.try_into().or(Err(libc::EINVAL))?,
+                b.try_into().or(Err(libc::EINVAL))?,
+                c.try_into().or(Err(libc::EINVAL))?,
                 d.into(),
             ),
             libc::SYS_epoll_wait => self.epoll_wait(
-                usize::from(a) as _,
+                a.try_into().or(Err(libc::EINVAL))?,
                 b.into(),
-                usize::from(c) as _,
-                usize::from(d) as _,
+                c.try_into().or(Err(libc::EINVAL))?,
+                d.try_into().or(Err(libc::EINVAL))?,
             ),
             libc::SYS_epoll_pwait => self.epoll_pwait(
-                usize::from(a) as _,
+                a.try_into().or(Err(libc::EINVAL))?,
                 b.into(),
-                usize::from(c) as _,
-                usize::from(d) as _,
+                c.try_into().or(Err(libc::EINVAL))?,
+                d.try_into().or(Err(libc::EINVAL))?,
                 e.into(),
             ),
 
             // NetworkSyscallHandler
             libc::SYS_socket => self.socket(
-                usize::from(a) as _,
-                usize::from(b) as _,
-                usize::from(c) as _,
+                a.try_into().or(Err(libc::EINVAL))?,
+                b.try_into().or(Err(libc::EINVAL))?,
+                c.try_into().or(Err(libc::EINVAL))?,
             ),
-            libc::SYS_bind => self.bind(usize::from(a) as _, b.into(), c.into()),
-            libc::SYS_listen => self.listen(usize::from(a) as _, usize::from(b) as _),
-            libc::SYS_getsockname => self.getsockname(usize::from(a) as _, b.into(), c.into()),
-            libc::SYS_accept => self.accept(usize::from(a) as _, b.into(), c.into()),
-            libc::SYS_accept4 => {
-                self.accept4(usize::from(a) as _, b.into(), c.into(), usize::from(d) as _)
+            libc::SYS_bind => self.bind(a.try_into().or(Err(libc::EINVAL))?, b.into(), c.into()),
+            libc::SYS_listen => self.listen(
+                a.try_into().or(Err(libc::EINVAL))?,
+                b.try_into().or(Err(libc::EINVAL))?,
+            ),
+            libc::SYS_getsockname => {
+                self.getsockname(a.try_into().or(Err(libc::EINVAL))?, b.into(), c.into())
             }
-            libc::SYS_connect => self.connect(usize::from(a) as _, b.into(), c.into()),
-            libc::SYS_recvfrom => self.recvfrom(
-                usize::from(a) as _,
+            libc::SYS_accept => {
+                self.accept(a.try_into().or(Err(libc::EINVAL))?, b.into(), c.into())
+            }
+            libc::SYS_accept4 => self.accept4(
+                a.try_into().or(Err(libc::EINVAL))?,
                 b.into(),
                 c.into(),
-                usize::from(d) as _,
+                d.try_into().or(Err(libc::EINVAL))?,
+            ),
+            libc::SYS_connect => {
+                self.connect(a.try_into().or(Err(libc::EINVAL))?, b.into(), c.into())
+            }
+            libc::SYS_recvfrom => self.recvfrom(
+                a.try_into().or(Err(libc::EINVAL))?,
+                b.into(),
+                c.into(),
+                d.try_into().or(Err(libc::EINVAL))?,
                 e.into(),
                 f.into(),
             ),
             libc::SYS_sendto => self.sendto(
-                usize::from(a) as _,
+                a.try_into().or(Err(libc::EINVAL))?,
                 b.into(),
                 c.into(),
-                usize::from(d) as _,
+                d.try_into().or(Err(libc::EINVAL))?,
                 e.into(),
                 f.into(),
             ),
             libc::SYS_setsockopt => self.setsockopt(
-                usize::from(a) as _,
-                usize::from(b) as _,
-                usize::from(c) as _,
+                a.try_into().or(Err(libc::EINVAL))?,
+                b.try_into().or(Err(libc::EINVAL))?,
+                c.try_into().or(Err(libc::EINVAL))?,
                 d.into(),
-                usize::from(e) as _,
+                e.try_into().or(Err(libc::EINVAL))?,
             ),
 
             SYS_ENARX_GETATT => self.get_attestation(a.into(), b.into(), c.into(), d.into()),

--- a/internal/untrusted/Cargo.toml
+++ b/internal/untrusted/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-primordial = "0.1"
+primordial = { git = "https://github.com/enarx/primordial" }


### PR DESCRIPTION
`usize::from(a) as _` can be transformed to
`a.try_into().or(Err(libc::EINVAL))?`

with the not yet released primordial 0.2

Because the `sgx` crate still uses primordial 0.1,
`internal/shim-sgx/src/event.rs` and `internal/shim-sgx/src/handler.rs`
are force transmuted as a workaround for now.

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
