### PR TITLE
Embed pubkey hash in ReportData

### DIFF
--- a/tests/bin/get_att.c
+++ b/tests/bin/get_att.c
@@ -4,7 +4,7 @@
 
 int main(void) {
     // TODO: Good buffer length?
-    unsigned char nonce[512];
+    unsigned char nonce[64];
     unsigned char buf[4598];
     size_t technology;
 


### PR DESCRIPTION
The hash is passed in through the nonce parameter in the `get_attestation()` syscall.

Depends on #301 to pass CI.

Resolves https://github.com/enarx/enarx/issues/918