### PR TITLE
Return Quote len and embed ReportData in SGX get_attestation()

### DIFF
--- a/src/backend/sgx/attestation.rs
+++ b/src/backend/sgx/attestation.rs
@@ -277,10 +277,12 @@ pub fn get_attestation(
     // also still run the tests. See https://github.com/enarx/enarx-keepldr/issues/228.
     if UnixStream::connect(AESM_SOCKET).is_err() {
         match nonce {
+            // Returns dummy TargetInfo
             0 => {
                 out_buf.copy_from_slice(&SGX_DUMMY_TI);
                 return Ok(SGX_TI_SIZE);
             }
+            // Returns dummy Quote
             _ => {
                 out_buf.copy_from_slice(&SGX_DUMMY_QUOTE);
                 return Ok(SGX_QUOTE_SIZE);
@@ -288,10 +290,12 @@ pub fn get_attestation(
         }
     };
 
+    // Returns TargetInfo
     if nonce == 0 {
         let akid = get_ak_id().expect("error obtaining att key id");
         let pkeysize = get_key_size(akid.clone()).expect("error obtaining key size");
         get_ti(akid, pkeysize, out_buf)
+    // Returns Quote
     } else {
         let akid = get_ak_id().unwrap();
         let report: &[u8] = unsafe { from_raw_parts(nonce as *const u8, nonce_len) };

--- a/tests/bin/get_att.c
+++ b/tests/bin/get_att.c
@@ -3,8 +3,7 @@
 #include <errno.h>
 
 int main(void) {
-    // TODO: Good buffer length?
-    unsigned char nonce[512];
+    unsigned char nonce[64]; /* correct hash length for SGX */
     unsigned char buf[4598];
     size_t technology;
 

--- a/tests/bin/sgx_get_att_quote.c
+++ b/tests/bin/sgx_get_att_quote.c
@@ -7,7 +7,7 @@
  * the returned Quote in buf match expected values. */
 
 int main(void) {
-    int* nonce = NULL;
+    int* nonce[1]; /* non-NULL nonce requests Quote */
     unsigned char buf[4598];
     size_t technology;
     int i = 0;

--- a/tests/bin/sgx_get_att_quote.c
+++ b/tests/bin/sgx_get_att_quote.c
@@ -7,7 +7,7 @@
  * the returned Quote in buf match expected values. */
 
 int main(void) {
-    int* nonce[1]; /* non-NULL nonce requests Quote */
+    int* nonce[64]; /* empty pseudo-hash value to embed in SGX Quote */
     unsigned char buf[4598];
     size_t technology;
     int i = 0;

--- a/tests/bin/sgx_get_att_quote_size.c
+++ b/tests/bin/sgx_get_att_quote_size.c
@@ -1,0 +1,22 @@
+#include "libc.h"
+#include "enarx.h"
+#include <errno.h>
+
+/* This test will be run only for SGX. It is designed to request a
+ * Quote size from get_attestation() and check that against the expected
+ * Quote size. */
+
+int main(void) {
+    int* nonce = NULL;
+    int* buf = NULL;
+    size_t technology;
+    ssize_t expected = 4598;
+
+    ssize_t size = get_att(nonce, sizeof(nonce), buf, sizeof(buf), &technology);
+
+    /* this test is SGX-specific, so just return success if not running on SGX */
+    if (technology != TEE_SGX)
+        return 0;
+
+    return (size != expected);
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -311,6 +311,13 @@ fn sgx_get_att_quote() {
     run_test("sgx_get_att_quote", 0, None, None, None);
 }
 
+#[cfg(feature = "backend-sgx")]
+#[test]
+#[serial]
+fn sgx_get_att_quote_size() {
+    run_test("sgx_get_att_quote_size", 0, None, None, None);
+}
+
 #[cfg(feature = "backend-sev")]
 #[test]
 #[serial]


### PR DESCRIPTION
In this PR:

- Return a Quote length to the code layer if nonce value is NULL
- Embed hash into ReportData if nonce (hash) value is non-NULL and 64 in length

Resolves #313 
Resolves enarx/enarx#918