### PR TITLE
fix(shim-sev): rename `RWLocked` to `RwLocked`

### DIFF
--- a/internal/shim-sev/src/allocator.rs
+++ b/internal/shim-sev/src/allocator.rs
@@ -5,7 +5,7 @@
 use crate::addr::{ShimPhysAddr, ShimVirtAddr};
 use crate::hostcall::HOST_CALL_ALLOC;
 use crate::hostmap::HOSTMAP;
-use crate::spin::RWLocked;
+use crate::spin::RwLocked;
 use crate::{get_cbit_mask, BOOT_INFO, C_BIT_MASK};
 use core::alloc::{GlobalAlloc, Layout};
 use core::convert::TryFrom;
@@ -34,8 +34,8 @@ use x86_64::{align_down, PhysAddr, VirtAddr};
 pub struct Page2MiB([u8; bytes![2; MiB]]);
 
 /// The global EnarxAllocator RwLock
-pub static ALLOCATOR: Lazy<RWLocked<EnarxAllocator>> =
-    Lazy::new(|| RWLocked::<EnarxAllocator>::new(unsafe { EnarxAllocator::new() }));
+pub static ALLOCATOR: Lazy<RwLocked<EnarxAllocator>> =
+    Lazy::new(|| RwLocked::<EnarxAllocator>::new(unsafe { EnarxAllocator::new() }));
 
 /// The allocator
 ///
@@ -489,7 +489,7 @@ fn shim_virt_to_enc_phys<T>(p: *mut T) -> PhysAddr {
     PhysAddr::new(phys.raw().raw() | get_cbit_mask())
 }
 
-unsafe impl GlobalAlloc for RWLocked<EnarxAllocator> {
+unsafe impl GlobalAlloc for RwLocked<EnarxAllocator> {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let mut this = self.write();
         this.try_alloc(layout)

--- a/internal/shim-sev/src/hostmap.rs
+++ b/internal/shim-sev/src/hostmap.rs
@@ -42,7 +42,7 @@
 use crate::addr::{HostVirtAddr, ShimPhysUnencryptedAddr};
 
 use crate::print::PrintBarrier;
-use crate::spin::RWLocked;
+use crate::spin::RwLocked;
 use core::alloc::Layout;
 use core::mem::{align_of, size_of};
 use linked_list_allocator::Heap;
@@ -51,8 +51,8 @@ use primordial::{Address, Page as Page4KiB};
 use spinning::Lazy;
 
 /// The global [`HostMap`](HostMap) RwLock
-pub static HOSTMAP: Lazy<RWLocked<HostMap>> =
-    Lazy::new(|| RWLocked::<HostMap>::new(HostMap::new()));
+pub static HOSTMAP: Lazy<RwLocked<HostMap>> =
+    Lazy::new(|| RwLocked::<HostMap>::new(HostMap::new()));
 
 struct HostMemListPageHeader {
     next: Option<&'static mut HostMemListPage>,
@@ -163,7 +163,7 @@ impl HostMap {
     }
 }
 
-impl RWLocked<HostMap> {
+impl RwLocked<HostMap> {
     /// Extend the number of slots in the map
     pub fn extend_slots(&self, mem_slots: usize, allocator: &mut Heap) {
         // While updating the HostMap the syscall proxying can't be used,

--- a/internal/shim-sev/src/spin.rs
+++ b/internal/shim-sev/src/spin.rs
@@ -26,11 +26,11 @@ impl<A> Locked<A> {
 }
 
 /// A wrapper around spinning::RwLock to permit trait implementations.
-pub struct RWLocked<A> {
+pub struct RwLocked<A> {
     inner: RwLock<A>,
 }
 
-impl<A> RWLocked<A> {
+impl<A> RwLocked<A> {
     /// Constructor
     #[inline]
     pub const fn new(inner: A) -> Self {


### PR DESCRIPTION
clippy complains with:

```
error: name `RWLocked` contains a capitalized acronym
Error:   --> src/spin.rs:29:12
   |
29 | pub struct RWLocked<A> {
   |            ^^^^^^^^ help: consider making the acronym lowercase,
                               except the initial letter
                               (notice the capitalization): `RwLocked`
```

Signed-off-by: Harald Hoyer <harald@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
