### PR TITLE
Implement uname() syscall test

### DIFF
--- a/tests/bin/libc.h
+++ b/tests/bin/libc.h
@@ -5,6 +5,7 @@
 #include <time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/utsname.h>
 
 int *__errno_location(void) {
     static int errnum = 0;
@@ -190,6 +191,24 @@ int close(int fd) {
         "syscall"
         : "=a" (rax)
         : "a" (SYS_close), "D" (fd)
+        : "%rcx", "%r11"
+    );
+
+    if (rax < 0) {
+        errno = -rax;
+        return -1;
+    }
+
+    return rax;
+}
+
+int uname(struct utsname *buf) {
+    ssize_t rax;
+
+    asm(
+        "syscall"
+        : "=a" (rax)
+        : "a" (SYS_uname), "D" (buf)
         : "%rcx", "%r11"
     );
 

--- a/tests/bin/uname.c
+++ b/tests/bin/uname.c
@@ -1,0 +1,27 @@
+#include "libc.h"
+
+int strcmp(const char* s1, const char* s2)
+{
+    while(*s1 && (*s1==*s2))
+        s1++,s2++;
+    return *(const unsigned char*)s1-*(const unsigned char*)s2;
+}
+
+int main(void) {
+
+    int v;
+    char *l = "Linux";
+    struct utsname buffer;
+
+    errno = 0;
+    if (uname(&buffer) != 0) {
+       return 1;
+    }
+
+    v = strcmp(buffer.sysname, l);
+    if (v != 0) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -234,6 +234,12 @@ fn echo() {
 
 #[test]
 #[serial]
+fn uname() {
+    run_test("uname", 0, None, None, None);
+}
+
+#[test]
+#[serial]
 fn unix_echo() {
     let tmpdir = Arc::new(TempDir::new("unix_echo").unwrap());
     const FILENAME_IN: &'static str = "enarx_unix_echo_to_bin";


### PR DESCRIPTION
This will close #340. Currently I'm getting odd behavior, where `strcmp` isn't recognized in `tests/bin/uname.c`, even though I've included `#include <string.h>` in `tests/bin/libc.h`.

The same code in `tests/bin/uname.c` compiles and runs as expected, when the headers below are included directly, rather than in `libc.h`, and the code is compiled standalone, outside of the test harness. I confess I'm stumped.

```
#include <errno.h>
#include <sys/utsname.h>
#include <string.h>
```

Edit: @haraldh explained the issue. I reimplemented `strcmp` as a function.