### PR TITLE
fix: remove last `;` from noreturn functions

### DIFF
--- a/internal/shim-sev/src/hostcall.rs
+++ b/internal/shim-sev/src/hostcall.rs
@@ -218,5 +218,5 @@ pub fn shim_exit(status: i32) -> ! {
     }
 
     // provoke triple fault, causing a VM shutdown
-    unsafe { _enarx_asm_triple_fault() };
+    unsafe { _enarx_asm_triple_fault() }
 }

--- a/internal/shim-sev/src/main.rs
+++ b/internal/shim-sev/src/main.rs
@@ -90,7 +90,7 @@ pub unsafe fn switch_shim_stack(ip: extern "C" fn() -> !, sp: u64) -> ! {
         SP = in(reg) sp,
         IP = in(reg) ip,
         options(noreturn, nomem)
-    );
+    )
 }
 
 /// Defines the entry point function.
@@ -171,7 +171,7 @@ pub fn panic(info: &core::panic::PanicInfo) -> ! {
     }
 
     // provoke triple fault, causing a VM shutdown
-    unsafe { _enarx_asm_triple_fault() };
+    unsafe { _enarx_asm_triple_fault() }
 }
 
 #[inline(never)]

--- a/internal/shim-sev/src/payload.rs
+++ b/internal/shim-sev/src/payload.rs
@@ -192,6 +192,6 @@ pub fn execute_payload() -> ! {
 
     unsafe {
         PAYLOAD_READY.store(true, Ordering::Relaxed);
-        usermode(entry.as_u64(), sp_handle);
+        usermode(entry.as_u64(), sp_handle)
     }
 }

--- a/internal/shim-sev/src/syscall.rs
+++ b/internal/shim-sev/src/syscall.rs
@@ -112,7 +112,7 @@ pub unsafe extern "sysv64" fn _syscall_enter() -> ! {
     USER_CODE_SEGMENT = const USER_CODE_SEGMENT,
     syscall_rust = sym syscall_rust,
     options(noreturn)
-    );
+    )
 }
 
 /// Handle a syscall in rust
@@ -195,7 +195,7 @@ impl BaseSyscallHandler for Handler {
 
     fn attacked(&mut self) -> ! {
         // provoke triple fault, causing a VM shutdown
-        unsafe { _enarx_asm_triple_fault() };
+        unsafe { _enarx_asm_triple_fault() }
     }
 
     fn translate_shim_to_host_addr<T>(buf: *const T) -> usize {

--- a/internal/shim-sev/src/usermode.rs
+++ b/internal/shim-sev/src/usermode.rs
@@ -53,5 +53,5 @@ pub unsafe fn usermode(ip: u64, sp: u64) -> ! {
     USER_CODE_SEGMENT = const USER_CODE_SEGMENT,
     IP = in(reg) ip,
     options(noreturn, nomem)
-    );
+    )
 }


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@hoyer.xyz>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
