### PR TITLE
fix: let parse-trace.sh work with shim kernel addresses

### DIFF
--- a/helper/parse-trace.sh
+++ b/helper/parse-trace.sh
@@ -23,7 +23,7 @@ while read line; do
         continue
     fi
 
-    if [[ $line = "Error: Shutdown"* ]]; then
+    if [[ $line = "Error: Shutdown"* ]] || [[ $line = "Error: MmioRead"* ]]; then
         ADDR2LINE="REGS"
         continue
     fi
@@ -45,6 +45,9 @@ while read line; do
         if [[ $line = *"rflags:"* ]] || [[ $line = *"rsp:"* ]] || [[ $line = *"rbp:"* ]] || [[ $line = *"rbx:"* ]]; then
             continue
         fi
+        line=${line%,}
+        read _ line <<< "$line"
+        line=${line/ffffff8}
     fi
 
     if [[ $ADDR2LINE = "TRACE" ]] && [[ $line = "P "* ]]; then


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@hoyer.xyz>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
