### PR TITLE
fix(shim-sev): reference the last symbol outstanding

### DIFF
--- a/internal/shim-sev/src/start.rs
+++ b/internal/shim-sev/src/start.rs
@@ -16,6 +16,7 @@ const INITIAL_STACK_PAGES: usize = 50;
 
 #[no_mangle]
 static INITIAL_SHIM_STACK: [Page; INITIAL_STACK_PAGES] = [Page::zeroed(); INITIAL_STACK_PAGES];
+use crate::_start_main;
 
 /// The initial function called at startup
 ///
@@ -201,11 +202,12 @@ pub unsafe extern "sysv64" fn _start() -> ! {
     // call _start_main
     // arg1 %rdi  = address of SYSCALL_PAGE (boot_info)
     // arg2 %rsi  = SEV C-bit mask
-    call    _start_main
+    call    {START_MAIN}
     ",
     SHIM_VIRT_OFFSET = const SHIM_VIRT_OFFSET,
     SIZE_OF_INITIAL_STACK = const INITIAL_STACK_PAGES * 4096,
     DYN_RELOC = sym _dyn_reloc,
+    START_MAIN = sym _start_main,
     PML4T = sym PML4T,
     PDPT_OFFSET = sym PDPT_OFFSET,
     PDT_OFFSET = sym PDT_OFFSET,


### PR DESCRIPTION
Remove the `entry_point` macro and reference the `_start_main` rust
function symbol properly from the `_start` asm block.

Signed-off-by: Harald Hoyer <harald@hoyer.xyz>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
