### PR TITLE
Refactor code for ergonomics and assembly reduction

### DIFF
--- a/internal/shim-sgx/src/enclave.rs
+++ b/internal/shim-sgx/src/enclave.rs
@@ -29,8 +29,14 @@ mod _internal {
     /// Clear CPU flags, extended state and temporary registers (`r10` and `r11`)
     ///
     /// This function clears CPU state during enclave transitions.
+    ///
+    /// # Safety
+    ///
+    /// This function should be safe as it only modifies non-preserved
+    /// registers. In fact, in addition to the declared calling convention,
+    /// we promise not to modify any of the parameter registers.
     #[naked]
-    extern "C" fn clearx() {
+    extern "sysv64" fn clearx() {
         static XSAVE: XSave = XSave::DEFAULT;
 
         unsafe {
@@ -56,7 +62,7 @@ mod _internal {
 
                 XSAVE = sym XSAVE,
                 options(noreturn)
-            );
+            )
         }
     }
 

--- a/internal/shim-sgx/src/entry.rs
+++ b/internal/shim-sgx/src/entry.rs
@@ -66,8 +66,7 @@ fn crt0setup<'a>(
     builder.done()
 }
 
-#[no_mangle]
-pub extern "C" fn entry(_rdi: u64, _rsi: u64, _rdx: u64, layout: &Layout, _r8: u64, _r9: u64) -> ! {
+pub fn entry(layout: &Layout) -> ! {
     // Validate the ELF header.
     let hdr = unsafe { &*(layout.code.start as *const Header) };
 

--- a/internal/shim-sgx/src/hostlib.rs
+++ b/internal/shim-sgx/src/hostlib.rs
@@ -5,7 +5,7 @@
 use lset::Line;
 
 /// The enclave layout
-#[repr(C)]
+#[repr(C, align(4096))]
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 pub struct Layout {
     /// The boundaries of the enclave.

--- a/internal/shim-sgx/src/main.rs
+++ b/internal/shim-sgx/src/main.rs
@@ -16,6 +16,7 @@ extern crate compiler_builtins;
 extern crate rcrt1;
 
 #[panic_handler]
+#[cfg(not(test))]
 #[allow(clippy::empty_loop)]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
@@ -75,3 +76,53 @@ mod hostlib;
 use hostlib::Layout;
 
 sallyport::declare_abi_version!();
+
+use sallyport::Block;
+use sgx::types::ssa::{Exception, StateSaveArea};
+
+// Opcode constants, details in Volume 2 of the Intel 64 and IA-32 Architectures Software
+// Developer's Manual
+const OP_SYSCALL: &[u8] = &[0x0f, 0x05];
+const OP_CPUID: &[u8] = &[0x0f, 0xa2];
+
+#[repr(C)]
+struct Context {
+    layout: hostlib::Layout,
+    ssa: [StateSaveArea],
+}
+
+#[repr(C)]
+struct Input {
+    cssa: usize,
+    ctx: &'static mut Context,
+}
+
+#[allow(unreachable_code)]
+extern "C" fn main(
+    _rdi: usize,
+    _rsi: usize,
+    rdx: &mut Block,
+    rcx: &mut Input,
+    _r8: usize,
+    _r9: usize,
+) {
+    match rcx.cssa {
+        0 => entry::entry(&rcx.ctx.layout),
+        1 => event::event(&rcx.ctx.layout, &mut rcx.ctx.ssa[0], rdx),
+        n => {
+            let gpr = &mut rcx.ctx.ssa[n - 1].gpr;
+
+            if let Some(Exception::InvalidOpcode) = gpr.exitinfo.exception() {
+                if let OP_SYSCALL = unsafe { gpr.rip.into_slice(2usize) } {
+                    // Skip the syscall instruction.
+                    let mut rip = usize::from(gpr.rip);
+                    rip += OP_SYSCALL.len();
+                    gpr.rip = rip.into();
+                    return;
+                }
+            }
+
+            unreachable!()
+        }
+    }
+}


### PR DESCRIPTION
This contains some pretty big refactoring in preparation for the "elf loader" transition. The biggest win is that we throw a way a big chunk of assembly code. The resulting code is easier to use, easier to reason about and less error prone.