### PR TITLE
feat(loader): let `Component::from_bytes()` be generic with `AsRef`

### DIFF
--- a/src/binary/component.rs
+++ b/src/binary/component.rs
@@ -31,7 +31,11 @@ pub struct Component<'a> {
 
 impl<'a> Component<'a> {
     /// Loads a binary from bytes
-    fn from_bytes(bytes: &'a [u8], component_type: ComponentType) -> Result<Self> {
+    fn from_bytes(
+        bytes: &'a (impl AsRef<[u8]> + ?Sized),
+        component_type: ComponentType,
+    ) -> Result<Self> {
+        let bytes = bytes.as_ref();
         // Parse the file.
         let elf = Elf::parse(bytes).unwrap();
 


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@hoyer.xyz>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
