### PR TITLE
fix: use preferred segmentation functions

### DIFF
--- a/internal/shim-sev/Cargo.lock
+++ b/internal/shim-sev/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "compiler_builtins"
@@ -163,9 +163,9 @@ checksum = "e4c2dbd44eb8b53973357e6e207e370f0c1059990df850aca1eca8947cf464f0"
 
 [[package]]
 name = "x86_64"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c54a17492391c594753ce2a180142bec7ad2876543565c2a08aa11cddef251"
+checksum = "d95947de37ad0d2d9a4a4dd22e0d042e034e5cbd7ab53edbca0d8035e0a6a64d"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/internal/shim-sev/src/gdt.rs
+++ b/internal/shim-sev/src/gdt.rs
@@ -7,7 +7,7 @@ use crate::syscall::_syscall_enter;
 use core::ops::Deref;
 use nbytes::bytes;
 use spinning::Lazy;
-use x86_64::instructions::segmentation::{load_ds, load_es, load_fs, load_gs, load_ss, set_cs};
+use x86_64::instructions::segmentation::{Segment, CS, DS, ES, FS, GS, SS};
 use x86_64::instructions::tables::load_tss;
 use x86_64::registers::model_specific::{KernelGsBase, LStar, SFMask, Star};
 use x86_64::registers::rflags::RFlags;
@@ -148,16 +148,16 @@ pub unsafe fn init() {
     GDT.0.load();
 
     // Setup the segment registers with the corresponding selectors
-    set_cs(GDT.1.code);
-    load_ss(GDT.1.data);
+    CS::set_reg(GDT.1.code);
+    SS::set_reg(GDT.1.data);
     load_tss(GDT.1.tss);
 
     // Clear the other segment registers
-    load_ss(SegmentSelector(0));
-    load_ds(SegmentSelector(0));
-    load_es(SegmentSelector(0));
-    load_fs(SegmentSelector(0));
-    load_gs(SegmentSelector(0));
+    SS::set_reg(SegmentSelector(0));
+    DS::set_reg(SegmentSelector(0));
+    ES::set_reg(SegmentSelector(0));
+    FS::set_reg(SegmentSelector(0));
+    GS::set_reg(SegmentSelector(0));
 
     // Set the selectors to be set when userspace uses `syscall`
     Star::write(GDT.1.user_code, GDT.1.user_data, GDT.1.code, GDT.1.data).unwrap();


### PR DESCRIPTION
The old ones are deprecated in the x86_64 crate.

Signed-off-by: Harald Hoyer <harald@hoyer.xyz>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
