### PR TITLE
Move enclave creation structures from sgx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "sgx",
  "structopt",
  "tempdir",
+ "vdso",
  "walkdir",
  "x86_64",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ is-it-maintained-open-issues = { repository = "enarx/enarx-keepldr" }
 default = ["backend-kvm", "backend-sgx"]
 
 backend-kvm = ["x86_64", "kvm-bindings", "kvm-ioctls"]
-backend-sgx = ["sgx"]
+backend-sgx = ["x86_64", "sgx"]
 
 [dependencies]
 sgx = { git = "https://github.com/enarx/sgx", rev = "a0b881cc798f3bafb8d603fa1bad6ca7b2a2c740", features = ["asm", "crypto"], optional = true }
@@ -51,6 +51,7 @@ semver = "1.0"
 goblin = "0.4"
 libc = "0.2"
 lset = "0.2"
+vdso = "0.1"
 
 [build-dependencies]
 cc = "1.0"

--- a/src/backend/sgx/enclave/builder.rs
+++ b/src/backend/sgx/enclave/builder.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{ioctls, Enclave};
+
+use lset::Span;
+use mmarinus::{perms, Kind, Map};
+use primordial::Page;
+use sgx::loader::{Flags, Loader};
+use sgx::types::page::{self, Class, SecInfo};
+use sgx::types::{secs::*, sig::*};
+
+use std::fs::{File, OpenOptions};
+use std::io::{Error, Result};
+use std::mem::forget;
+use std::num::NonZeroU32;
+use std::sync::{Arc, RwLock};
+
+/// A structs which assists in enclave creation
+///
+/// 1. Instantiate the `Builder` using `Builder::new()` or `Builder::new_at()`.
+/// 2. Add pages to the enclave using `Builder::load()` (see the `Loader` trait).
+/// 3. Finalize the enclave contents using `Builder::build()`.
+pub struct Builder {
+    file: File,
+    mmap: Map<perms::Unknown>,
+    perm: Vec<(Span<usize>, SecInfo)>,
+    tcsp: Vec<usize>,
+}
+
+impl Builder {
+    /// Creates a new `Builder` instance at the given location
+    ///
+    /// The enclave will be placed in the provided memory map, which must be
+    /// sized to a power of two and naturally aligned.
+    ///
+    /// This call also defines the enclave signature `Parameters` as well as
+    /// the number of pages in each SSA frame. Note that while this call
+    /// defines the size of each SSA frame, each thread (i.e. TCS page) can
+    /// have a different number of SSA frames.
+    ///
+    /// For those familiar with the Intel documentation, this function wraps
+    /// the call to the kernel to issue the `ECREATE` instruction.
+    pub fn new_at(
+        mmap: Map<perms::None>,
+        ssa_frame_pages: NonZeroU32,
+        parameters: Parameters,
+    ) -> Result<Self> {
+        let span = Span {
+            start: mmap.addr(),
+            count: mmap.size(),
+        };
+
+        // Validate the mapping constraints
+        if span.count == 0 || !span.count.is_power_of_two() || span.start % span.count != 0 {
+            return Err(Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        // Open the device.
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/sgx_enclave")?;
+
+        // Create the enclave.
+        let secs = Secs::new(span, ssa_frame_pages, parameters);
+        let create = ioctls::Create::new(&secs);
+        ioctls::ENCLAVE_CREATE.ioctl(&mut file, &create)?;
+
+        Ok(Self {
+            file,
+            mmap: mmap.into(), // Discard typed permissions
+            perm: Vec::new(),
+            tcsp: Vec::new(),
+        })
+    }
+
+    /// Creates a new `Builder` instance at the given location
+    ///
+    /// A memory mapping for this enclave will be automatically created with
+    /// the specified size. The location for this mapping will be determined
+    /// by the kernel.
+    ///
+    /// This call also defines the enclave signature `Parameters` as well as
+    /// the number of pages in each SSA frame. Note that while this call
+    /// defines the size of each SSA frame, each thread (i.e. TCS page) can
+    /// have a different number of SSA frames.
+    ///
+    /// For those familiar with the Intel documentation, this function wraps
+    /// the call to the kernel to issue the `ECREATE` instruction.
+    pub fn new(size: usize, ssa_frame_pages: NonZeroU32, parameters: Parameters) -> Result<Self> {
+        // Map the memory for the enclave
+        // We map twice as much as we need so that we can naturally align it.
+        let map = Map::map(size * 2)
+            .anywhere()
+            .anonymously()
+            .known::<perms::None>(Kind::Private)?;
+
+        // Naturally align the mapping.
+        let addr = (map.addr() + size - 1) / size * size;
+        let (_, r) = map.split_at(addr)?;
+        let (l, _) = r.split(size)?;
+
+        Self::new_at(l, ssa_frame_pages, parameters)
+    }
+
+    /// Finalizes the SGX enclave
+    ///
+    /// This function finalizes the SGX enclave and prepares it for execution.
+    ///
+    /// For those familiar with the Intel documentation, this function wraps
+    /// the call to the kernel to issue the `EINIT` instruction.
+    pub fn build(mut self, signature: &Signature) -> Result<Arc<Enclave>> {
+        // Initialize the enclave.
+        let init = ioctls::Init::new(signature);
+        ioctls::ENCLAVE_INIT.ioctl(&mut self.file, &init)?;
+
+        // Fix up mapped permissions.
+        self.perm.sort_by(|l, r| l.0.start.cmp(&r.0.start));
+        for (span, si) in self.perm {
+            let rwx = match si.class {
+                Class::Tcs => libc::PROT_READ | libc::PROT_WRITE,
+                Class::Reg => {
+                    let mut prot = libc::PROT_NONE;
+
+                    if si.flags.contains(page::Flags::R) {
+                        prot |= libc::PROT_READ;
+                    }
+
+                    if si.flags.contains(page::Flags::W) {
+                        prot |= libc::PROT_WRITE;
+                    }
+
+                    if si.flags.contains(page::Flags::X) {
+                        prot |= libc::PROT_EXEC;
+                    }
+
+                    prot
+                }
+                _ => panic!("Unsupported class!"),
+            };
+
+            // Change the permissions on an existing region of memory.
+            forget(unsafe {
+                Map::map(span.count)
+                    .onto(span.start)
+                    .from(&mut self.file, 0)
+                    .unknown(Kind::Shared, rwx)?
+            });
+
+            //let line = lset::Line::from(span);
+            //eprintln!("{:016x}-{:016x} {:?}", line.start, line.end, si);
+        }
+
+        Ok(Arc::new(Enclave {
+            _mem: self.mmap,
+            tcs: RwLock::new(self.tcsp),
+        }))
+    }
+}
+
+impl Loader for Builder {
+    type Error = std::io::Error;
+
+    /// Adds pages to an enclave
+    ///
+    /// For those familiar with the Intel documentation, this function wraps
+    /// the call to the kernel to issue the `EADD` instruction.
+    fn load(
+        &mut self,
+        pages: impl AsRef<[Page]>,
+        offset: usize,
+        secinfo: SecInfo,
+        flags: impl Into<flagset::FlagSet<Flags>>,
+    ) -> Result<()> {
+        let offset = offset * Page::SIZE;
+        let pages = pages.as_ref();
+        let flags = flags.into();
+
+        // Ignore regions with no pages.
+        if pages.is_empty() {
+            return Ok(());
+        }
+
+        // Update the enclave.
+        let mut ap = ioctls::AddPages::new(pages, offset, &secinfo, flags);
+        ioctls::ENCLAVE_ADD_PAGES.ioctl(&mut self.file, &mut ap)?;
+
+        // Calculate an absolute span for this region.
+        let span = Span {
+            start: self.mmap.addr() + offset,
+            count: pages.len() * Page::SIZE,
+        };
+
+        // Save permissions fixups for later.
+        self.perm.push((span, secinfo));
+
+        // Keep track of TCS pages.
+        if secinfo.class == page::Class::Tcs {
+            for i in 0..pages.len() {
+                self.tcsp.push(span.start + i * Page::SIZE);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/backend/sgx/enclave/execute.rs
+++ b/src/backend/sgx/enclave/execute.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use primordial::{Address, Register};
+
+pub use x86_64::InterruptVector;
+
+use super::Thread;
+
+/// How to enter an enclave
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Entry {
+    /// Enter an enclave normally
+    Enter = 2,
+
+    /// Resume an enclave after an asynchronous exit
+    Resume = 3,
+}
+
+/// This struct assigns u16 for the trap field. But it contains only exception
+/// numbers, which are u8. Therefore, we don't use ExceptionInfo::unused.
+///
+/// TODO add more comprehensive docs
+#[derive(Copy, Clone, Debug)]
+pub struct ExceptionInfo {
+    /// Last entry type
+    pub last: Entry,
+
+    /// Interrupt vector
+    pub trap: InterruptVector,
+
+    /// Trapping code
+    pub code: u16,
+
+    /// Memory address where exception occurred
+    pub addr: Address<u64, ()>,
+}
+
+/// The registers that can be passed to/from the enclave
+#[repr(C)]
+#[derive(Default, Debug, PartialEq)]
+#[allow(missing_docs)]
+pub struct Registers {
+    pub rdi: Register<usize>,
+    pub rsi: Register<usize>,
+    pub rdx: Register<usize>,
+    pub r8: Register<usize>,
+    pub r9: Register<usize>,
+}
+
+// This structure is dictated by the Linux kernel.
+//
+// See: https://github.com/torvalds/linux/blob/84292fffc2468125632a21c09533a89426ea212e/arch/x86/include/uapi/asm/sgx.h#L112
+#[repr(C)]
+#[derive(Default, Debug)]
+struct Run {
+    tcs: Register<u64>,
+    function: u32,
+    exception_vector: u16,
+    exception_error_code: u16,
+    exception_addr: Address<u64, ()>,
+    user_handler: Register<u64>,
+    user_data: Register<u64>,
+    reserved: [u64; 27],
+}
+
+// This function signature is dictated by the Linux kernel.
+//
+// See: https://github.com/torvalds/linux/blob/84292fffc2468125632a21c09533a89426ea212e/arch/x86/include/uapi/asm/sgx.h#L92
+extern "C" fn handler(
+    rdi: Register<usize>,
+    rsi: Register<usize>,
+    rdx: Register<usize>,
+    _rsp: Register<usize>,
+    r8: Register<usize>,
+    r9: Register<usize>,
+    run: &mut Run,
+) -> libc::c_int {
+    let registers: *mut Registers = run.user_data.into();
+    let registers: &mut Registers = unsafe { &mut *registers };
+    registers.rdi = rdi;
+    registers.rsi = rsi;
+    registers.rdx = rdx;
+    registers.r8 = r8;
+    registers.r9 = r9;
+    0
+}
+
+impl Thread {
+    /// Enter an enclave.
+    ///
+    /// This function enters an enclave using `Entry` and provides the
+    /// specified `registers` to the enclave. On success, the `registers`
+    /// variable contains the registers returned from the enclave. Otherwise,
+    /// an asynchronous exit (AEX) has occurred and the details about the
+    /// exception are returned.
+    #[inline(always)]
+    pub fn enter(&mut self, how: Entry, registers: &mut Registers) -> Result<(), ExceptionInfo> {
+        let mut run = Run {
+            tcs: self.tcs.into(),
+            user_handler: (handler as usize).into(),
+            user_data: registers.into(),
+            ..Default::default()
+        };
+
+        // The `enclu` instruction consumes `rax`, `rbx` and `rcx`. However,
+        // the vDSO function preserves `rbx` AND sets `rax` as the return
+        // value. All other registers are passed to and from the enclave
+        // unmodified.
+        //
+        // Therefore, we use `rdx` to pass a single argument into and out from
+        // the enclave. We consider all other registers to be clobbered by the
+        // enclave itself.
+        let rax: i32;
+        unsafe {
+            asm!(
+                "push rbx",       // save rbx
+                "push rbp",       // save rbp
+                "mov  rbp, rsp",  // save rsp
+                "and  rsp, ~0xf", // align to 16+0
+
+                "push 0",         // align to 16+8
+                "push r10",       // push run address
+                "call r11",       // call vDSO function
+
+                "mov  rsp, rbp",  // restore rsp
+                "pop  rbp",       // restore rbp
+                "pop  rbx",       // restore rbx
+
+                inout("rdi") usize::from(registers.rdi) => _,
+                inout("rsi") usize::from(registers.rsi) => _,
+                inout("rdx") usize::from(registers.rdx) => _,
+                inout("rcx") how as u32 => _,
+                inout("r8") usize::from(registers.r8) => _,
+                inout("r9") usize::from(registers.r9) => _,
+                inout("r10") &mut run => _,
+                inout("r11") self.fnc => _,
+                lateout("r12") _,
+                lateout("r13") _,
+                lateout("r14") _,
+                lateout("r15") _,
+                lateout("rax") rax,
+            );
+        }
+
+        match (rax, run.function) {
+            (0, 4) => return Ok(()),
+            (0, 2) | (0, 3) => (),
+            _ => unreachable!(),
+        }
+
+        Err(ExceptionInfo {
+            trap: unsafe { core::mem::transmute(run.exception_vector as u8) },
+            code: run.exception_error_code,
+            addr: run.exception_addr,
+            last: unsafe { core::mem::transmute(run.function) },
+        })
+    }
+}

--- a/src/backend/sgx/enclave/ioctls.rs
+++ b/src/backend/sgx/enclave/ioctls.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements Intel SGX-related IOCTLs using the iocuddle crate.
+//! All references to Section or Tables are from
+//! https://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3d-part-4-manual.pdf
+
+use std::marker::PhantomData;
+
+use flagset::FlagSet;
+use iocuddle::*;
+use primordial::Page;
+use sgx::loader::Flags;
+use sgx::types::{page::SecInfo, secs, sig};
+
+const SGX: Group = Group::new(0xA4);
+
+/// IOCTL identifier for ECREATE (see Section 41-21)
+pub const ENCLAVE_CREATE: Ioctl<Write, &Create> = unsafe { SGX.write(0x00) };
+
+/// IOCTL identifier for EADD (see Section 41-11)
+pub const ENCLAVE_ADD_PAGES: Ioctl<WriteRead, &AddPages> = unsafe { SGX.write_read(0x01) };
+
+/// IOCTL identifier for EINIT (see Section 41-35)
+pub const ENCLAVE_INIT: Ioctl<Write, &Init> = unsafe { SGX.write(0x02) };
+
+//pub const ENCLAVE_SET_ATTRIBUTE: Ioctl<Write, &SetAttribute> = unsafe { SGX.write(0x03) };
+
+#[repr(C)]
+#[derive(Debug)]
+/// Struct for creating a new enclave from SECS
+pub struct Create<'a>(u64, PhantomData<&'a ()>);
+
+impl<'a> Create<'a> {
+    /// A new Create struct wraps an SECS struct from the sgx-types crate.
+    pub fn new(secs: &'a secs::Secs) -> Self {
+        Create(secs as *const _ as _, PhantomData)
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+/// Struct for adding pages to an enclave
+pub struct AddPages<'a> {
+    src: u64,
+    offset: u64,
+    length: u64,
+    secinfo: u64,
+    flags: u64,
+    count: u64,
+    phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> AddPages<'a> {
+    /// Creates a new AddPages struct for a page at a certain offset
+    pub fn new(
+        data: &'a [Page],
+        offset: usize,
+        secinfo: &'a SecInfo,
+        flags: impl Into<FlagSet<Flags>>,
+    ) -> Self {
+        const MEASURE: u64 = 1 << 0;
+
+        let data = unsafe { data.align_to::<u8>().1 };
+        let mut nflags = 0;
+
+        for flag in flags.into() {
+            nflags |= match flag {
+                Flags::Measure => MEASURE,
+            };
+        }
+
+        Self {
+            src: data.as_ptr() as _,
+            offset: offset as _,
+            length: data.len() as _,
+            secinfo: secinfo as *const _ as _,
+            flags: nflags,
+            count: 0,
+            phantom: PhantomData,
+        }
+    }
+
+    #[allow(dead_code)]
+    /// WIP
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+/// Struct for initializing an enclave
+pub struct Init<'a>(u64, PhantomData<&'a ()>);
+
+impl<'a> Init<'a> {
+    /// A new Init struct must wrap a Signature from the sgx-types crate.
+    pub fn new(sig: &'a sig::Signature) -> Self {
+        Init(sig as *const _ as _, PhantomData)
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+#[allow(dead_code)]
+/// Struct for setting enclave attributes - WIP - ERESUME? EREMOVE?
+pub struct SetAttribute<'a>(u64, PhantomData<&'a ()>);
+
+impl<'a> SetAttribute<'a> {
+    #[allow(dead_code)]
+    /// A new SetAttribute struct must wrap a file descriptor.
+    pub fn new(fd: &'a impl std::os::unix::io::AsRawFd) -> Self {
+        SetAttribute(fd.as_raw_fd() as _, PhantomData)
+    }
+}

--- a/src/backend/sgx/enclave/mod.rs
+++ b/src/backend/sgx/enclave/mod.rs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Overview of an Enclave
+//!
+//! Enclaves are constructed from:
+//!
+//!   1. One or more pages of code and data. This is the enclave contents.
+//!
+//!   2. One or more State Save Area (SSA) frames per thread. Each SSA frame
+//!      enables one layer of exception handling. During an exception, the
+//!      CPU performs an asynchronous enclave exit (AEX) where it store the
+//!      CPU state in the current SSA frame (CSSA) and then exits.
+//!
+//!   3. One Thread Control Structure (TCS) page per thread. Inside the
+//!      enclave, this page is accessed exclusively by the hardware. Each
+//!      TCS page contains the location and number of the thread's SSA
+//!      frames as well as the address of the enclave to jump to when
+//!      entering (i.e. the entry point).
+//!
+//! # Building an Enclave
+//!
+//! This `Builder` object will help you construct an enclave. First, you will
+//! instantiate the `Builder` using `Builder::new()` or `Builder::new_at()`.
+//! Next, you will add all the relevant pages using the `Loader::load()`
+//! trait method. Finally, you will call `Builder::build()` to verify the
+//! enclave signature and finalize the enclave construction.
+//!
+//! # Executing an Enclave
+//!
+//! Once you have built an `Enclave` you will want to execute it. This is done
+//! by creating a new `Thread` object using `Enclave::spawn()`. Once you have
+//! a `Thread` object, you can use `Thread::enter()` to enter the enclave,
+//! passing the specified registers. When the enclave returns, you can read
+//! the register state from the same structure.
+//!
+//! # Additional Information
+//!
+//! The Intel SGX documentation is available [here]. Section references in
+//! further documentation refer to this document.
+//!
+//! [here]: https://www.intel.com/content/dam/www/public/emea/xe/en/documents/manuals/64-ia-32-architectures-software-developer-vol-3d-part-4-manual.pdf
+
+mod builder;
+mod execute;
+mod ioctls;
+
+pub use builder::Builder;
+pub use execute::{Entry, ExceptionInfo, InterruptVector, Registers};
+
+use std::sync::{Arc, RwLock};
+
+use mmarinus::{perms, Map};
+use vdso::Symbol;
+
+/// A full initialized enclave
+///
+/// To begin execution in this enclave, create a new `Thread` object using
+/// `Enclave::spawn()`.
+pub struct Enclave {
+    _mem: Map<perms::Unknown>,
+    tcs: RwLock<Vec<usize>>,
+}
+
+impl Enclave {
+    /// Create a new thread of execuation for an enclave.
+    ///
+    /// Note that this method does not create a system thread. If you want to
+    /// execute multiple enclave threads in parallel, you'll need to spawn
+    /// operating system threads in addition to this thread object.
+    pub fn spawn(self: Arc<Enclave>) -> Option<Thread> {
+        let fnc = vdso::Vdso::locate()
+            .expect("vDSO not found")
+            .lookup("__vdso_sgx_enter_enclave")
+            .expect("__vdso_sgx_enter_enclave not found");
+
+        let tcs = self.tcs.write().unwrap().pop()?;
+        Some(Thread {
+            enc: self,
+            tcs,
+            fnc,
+        })
+    }
+}
+
+/// A single thread of execution inside an enclave
+///
+/// You can begin enclave execution using `Thread::enter()`.
+pub struct Thread {
+    enc: Arc<Enclave>,
+    tcs: usize,
+    fnc: &'static Symbol,
+}
+
+impl Drop for Thread {
+    fn drop(&mut self) {
+        self.enc.tcs.write().unwrap().push(self.tcs)
+    }
+}

--- a/src/backend/sgx/mod.rs
+++ b/src/backend/sgx/mod.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
+mod enclave;
+
 use crate::backend::sgx::attestation::get_attestation;
 use crate::backend::{Command, Datum, Keep};
 use crate::binary::*;
+use enclave::{Builder, Enclave, Entry, InterruptVector, Registers};
 
 use anyhow::Result;
 use goblin::elf::program_header::*;
@@ -11,7 +14,6 @@ use primordial::{Page, Pages};
 use sallyport::syscall::{SYS_ENARX_CPUID, SYS_ENARX_GETATT};
 use sallyport::Block;
 use sgx::crypto::Hasher;
-use sgx::enclave::{Builder, Enclave, Entry, InterruptVector, Registers};
 use sgx::loader::{self, Loader};
 use sgx::types::page::{Class, Flags, SecInfo};
 use sgx::types::sig::{Author, Parameters};
@@ -189,7 +191,7 @@ impl super::Keep for Enclave {
 }
 
 struct Thread {
-    thread: sgx::enclave::Thread,
+    thread: enclave::Thread,
     registers: Registers,
     block: Block,
     cssa: usize,


### PR DESCRIPTION
I performed a dependency analysis of the types from the sgx crate. These
types are only used in this crate. Further, they encapsulate some
enarx-specific behavior and probably aren't useful outside enarx.
Therefore, I move them from the sgx crate into here. A separate PR will
remove these types from the sgx crate.

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>