### PR TITLE
Fix x86_64 locked dependency hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "x86_64"
 version = "0.14.4"
-source = "git+https://github.com/npmccallum/x86_64?branch=errors#502ba0c17b1feeb152390a91664d9ee939943071"
+source = "git+https://github.com/npmccallum/x86_64?branch=errors#48725307be8484b0ed690e6470669e3f51640372"
 dependencies = [
  "bit_field",
  "bitflags",


### PR DESCRIPTION
Due to [recent force-push on the upstream PR](https://github.com/rust-osdev/x86_64/pull/303#event-5288317994) the existing locked dependency hash became invalid, since the vendored [commit](https://github.com/npmccallum/x86_64/commit/502ba0c17b1feeb152390a91664d9ee939943071) is not present in the referenced branch anymore
Fixed the commit hash used in `Cargo.lock` to depend on the most recent commit and fix the build.
[Upstream diff](https://github.com/rust-osdev/x86_64/compare/502ba0c17b1feeb152390a91664d9ee939943071..48725307be8484b0ed690e6470669e3f51640372)

Note, that it seems that there are more changes expected to the referenced PR - if not based on top of https://github.com/npmccallum/x86_64/commit/48725307be8484b0ed690e6470669e3f51640372, they will break the build again

Perhaps a good idea would be to duplicate the branch and depend on the new branch to avoid the above until the upstream PR is merged and dependency is updated